### PR TITLE
Add security code field to token request

### DIFF
--- a/Omise-iOS_Example/Omise-iOS_Test/AccessOmiseViewController.m
+++ b/Omise-iOS_Example/Omise-iOS_Test/AccessOmiseViewController.m
@@ -42,6 +42,7 @@ bool succeeded;
     tokenRequest.card.number = @"4242424242424242"; //required
     tokenRequest.card.expirationMonth = @"11"; //required
     tokenRequest.card.expirationYear = @"2016"; //required
+    tokenRequest.card.securityCode = @"123"; //required
     
     Omise* omise = [Omise new];
     omise.delegate = self;

--- a/Omise-iOS_SDK/Omise-iOS.xcodeproj/xcuserdata/sirn.xcuserdatad/xcschemes/Omise-iOS.xcscheme
+++ b/Omise-iOS_SDK/Omise-iOS.xcodeproj/xcuserdata/sirn.xcuserdatad/xcschemes/Omise-iOS.xcscheme
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   version = "1.3">
+   <BuildAction>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65D0100A1A11B70D00B75F3D"
+               BuildableName = "Omise-iOS.app"
+               BlueprintName = "Omise-iOS"
+               ReferencedContainer = "container:Omise-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <LaunchAction
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65D0100A1A11B70D00B75F3D"
+            BuildableName = "Omise-iOS.app"
+            BlueprintName = "Omise-iOS"
+            ReferencedContainer = "container:Omise-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+</Scheme>

--- a/Omise-iOS_SDK/Omise-iOS/OmiseLib/Card.h
+++ b/Omise-iOS_SDK/Omise-iOS/OmiseLib/Card.h
@@ -25,6 +25,7 @@
 @property (nonatomic) NSString* fingerprint;
 @property (nonatomic) NSString* name;
 @property (nonatomic) NSString* created;
+@property (nonatomic) NSString* securityCode;
 @property (nonatomic) BOOL securityCodeCheck;
 
 @end

--- a/Omise-iOS_SDK/Omise-iOS/OmiseLib/JsonParser.m
+++ b/Omise-iOS_SDK/Omise-iOS/OmiseLib/JsonParser.m
@@ -17,7 +17,6 @@
                                                                options:NSJSONReadingAllowFragments
                                                                  error:nil];
     if(jsonObject){
-        
         NSString* obj = [jsonObject objectForKey:@"object"];
         if ([obj isEqualToString:@"error"]) {
             return nil;
@@ -45,7 +44,8 @@
         token.card.fingerprint = [cardObject objectForKey:@"fingerprint"];
         token.card.name = [cardObject objectForKey:@"name"];
         token.card.created = [cardObject objectForKey:@"created"];
-     
+        token.card.securityCodeCheck = [(NSNumber *)[cardObject objectForKey:@"security_code_check"]boolValue];
+
         return token;
     }
     

--- a/Omise-iOS_SDK/Omise-iOS/OmiseLib/Omise.m
+++ b/Omise-iOS_SDK/Omise-iOS/OmiseLib/Omise.m
@@ -48,13 +48,14 @@ enum OmiseApi{
     NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData timeoutInterval:15];
     [req setHTTPMethod:@"POST"];
     
-    NSString* body = [NSString stringWithFormat:@"card[name]=%@&card[city]=%@&card[postal_code]=%@&card[number]=%@&card[expiration_month]=%@&card[expiration_year]=%@",
+    NSString* body = [NSString stringWithFormat:@"card[name]=%@&card[city]=%@&card[postal_code]=%@&card[number]=%@&card[expiration_month]=%@&card[expiration_year]=%@&card[security_code]=%@",
                       mTokenRequest.card.name,
                       mTokenRequest.card.city,
                       mTokenRequest.card.postalCode,
                       mTokenRequest.card.number,
                       mTokenRequest.card.expirationMonth,
-                      mTokenRequest.card.expirationYear];
+                      mTokenRequest.card.expirationYear,
+                      mTokenRequest.card.securityCode];
     [req setHTTPBody:[body dataUsingEncoding:NSUTF8StringEncoding]];
     
     NSString *loginString = [NSString stringWithFormat:@"%@:%@", mTokenRequest.publicKey, @""];

--- a/README.jp.md
+++ b/README.jp.md
@@ -36,7 +36,7 @@ ExampleViewController.h
 @interface ExampleViewController : UIViewController <OmiseRequestTokenDelegate>
 @end
 ```
-    
+
 ExampleViewController.m
 ```objc
 #import "ExampleViewController.h"
@@ -45,7 +45,7 @@ ExampleViewController.m
 -(void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     //set parameters
     TokenRequest* tokenRequest = [TokenRequest new];
     tokenRequest.publicKey = @"pkey_test_4ya6kkbjfporhk3gwnt"; //required
@@ -55,7 +55,8 @@ ExampleViewController.m
     tokenRequest.card.number = @"4242424242424242"; //required
     tokenRequest.card.expirationMonth = @"11"; //required
     tokenRequest.card.expirationYear = @"2016"; //required
-    
+    tokenRequest.card.securityCode = @"123"; //required
+
     //request
     Omise* omise = [Omise new];
     omise.delegate = self;

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A class representing token. This class is what will be passed to the delegate if
 A class for requesting token. See also sample code below.
 
 ### Test app
+
 By opening Omise-iOS_Test.xcodeproj and building it on Xcode, the sample application will launch and create a charge token to test.
 
 ## Request a token
@@ -52,6 +53,7 @@ ExampleViewController.h
     tokenRequest.card.number = @"4242424242424242"; //required
     tokenRequest.card.expirationMonth = @"11"; //required
     tokenRequest.card.expirationYear = @"2016"; //required
+    tokenRequest.card.securityCode = @"123"; //required
 
     //request
     Omise* omise = [Omise new];


### PR DESCRIPTION
Add the missing `securityCode` property to `TokenRequest` and make `securityCodeCheck` actually returns something.