### PR TITLE
Document CocoaPods availability and track the podspec

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Omise Co., Ltd. <support@omise.co>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.jp.md
+++ b/README.jp.md
@@ -4,29 +4,36 @@ tokenを生成するiOS(Cocoa)のライブラリです。
 Omise-iosライブラリーは、Omise APIを用いたトークンの生成をするためのライブラリーです。 ライブラリーでトークンを生成する際に入力されるユーザカード情報は、あなたのサーバーを通る事はありません。 またこのライブラリーを用いる事で、ユーザーのカード情報を安全に保存し再度トークンをリクエストするだけでチャージすることができます。 この機能により、「1クリックチェックアウト」を実現する事ができます。 すべてのセンシティブパーソナルデータは私たちのPCI-DSS認証セキュアサーバーを通して行われ、安全かつ安心してご利用いただけるようにしております。
 
 
-
 ## Setup
-{repo root}/Omise-iOS/Omise-iOS/OmiseLib にある全てのファイルをプロジェクトにコピーしてください。
+
+`{repository root}/Omise-iOS/Omise-iOS/OmiseLib` にある全てのファイルをプロジェクトにコピーしてください。
 
 ## Primary classes
+
 ### Card
+
 クレジットカードを表現します。
 
 ### TokenRequest
+
 Tokenをリクエストする時に必要なパラメータを取りまとめるクラスです。このクラスのインスタンスに必要なパラメータをセットしてください。
 
 ### Token
+
 tokenを表現します。リクエストに成功した時、delegateで渡されてくるのはこのクラスのインスタンスです。
 
 ### Omise
+
 tokenをリクエストするクラスです。使い方は下記のサンプルコードをご覧ください。
 
 ### Test App
+
 Omise-iOS_Test.xcodeproj を開き、ビルドするとTokenを作成するサンプルアプリが起動します。
 
 ## Request a token
 
-ExampleViewController.h
+`ExampleViewController.h`:
+
 ```objc
 #import <UIKit/UIKit.h>
 #import "Omise.h"
@@ -37,7 +44,8 @@ ExampleViewController.h
 @end
 ```
 
-ExampleViewController.m
+`ExampleViewController.m`:
+
 ```objc
 #import "ExampleViewController.h"
 @implementation ExampleViewController
@@ -79,5 +87,4 @@ ExampleViewController.m
     NSString* location = token.location;
     BOOL livemode = token.livemode;
 }
-
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 omise-ios
 =========
 
-omise-ios is a Cocoa library for managing token with Omise API.
+omise-ios is a Cocoa library for managing credit cards and payment authorization with the Omise API.
 
-By using the token produced by this library, you will be able to securely process credit card without letting sensitive information pass through your server. This token can also be used to create customer card data which will allow re-using of card data for the next payment without entering it again.
+By using the tokens produced by this library, you will be able to securely process credit cards without letting sensitive information pass through your server. These tokens can also be used to store references to card details which allow customers to reuse cards for their future payments without entering their information again.
 
 All data are transmitted via HTTPS to our PCI-DSS certified server.
 
 ## Setup
 
-Please copy all files in {repo root}/Omise-iOS/Omise-iOS/OmiseLib into your project.
+Omise-iOS-Swift is available through [CocoaPods]. To install it, simply add the following line to your `Podfile`:
+
+    pod 'omise-ios', '~> 1.0'
+
+Alternatively, to install manually, please copy all files in `{repository root}/Omise-iOS/Omise-iOS/OmiseLib` into your project.
 
 ## Primary classes
 
@@ -35,7 +39,20 @@ By opening Omise-iOS_Test.xcodeproj and building it on Xcode, the sample applica
 
 ## Request a token
 
-ExampleViewController.h
+`ExampleViewController.h`:
+
+```objc
+#import <UIKit/UIKit.h>
+#import "Omise.h"
+#import "TokenRequest.h"
+#import "Card.h"
+
+@interface ExampleViewController : UIViewController <OmiseRequestTokenDelegate>
+@end
+```
+
+`ExampleViewController.m`:
+
 ```objc
 #import "ExampleViewController.h"
 @implementation ExampleViewController
@@ -77,5 +94,6 @@ ExampleViewController.h
     NSString* location = token.location;
     BOOL livemode = token.livemode;
 }
-
 ```
+
+[CocoaPods]: http://cocoapods.org/

--- a/omise-ios.podspec
+++ b/omise-ios.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name             = 'omise-ios'
+  s.version          = '1.0.1'
+  s.summary          = 'Client library for the Omise API'
+  s.description      = <<-DESC
+    omise-ios is a Cocoa library for managing payment authorization tokens
+    and stored credit card details with the Omise API.
+  DESC
+
+  s.homepage         = 'https://github.com/omise/omise-ios'
+  s.social_media_url = 'https://twitter.com/omise'
+  s.author           = { 'Omise' => 'support@omise.co' }
+  s.license          = 'MIT'
+  s.source           = { :git => 'https://github.com/omise/omise-ios.git',
+                         :tag => "v#{s.version}" }
+
+  s.platform     = :ios, '5.0'
+
+  s.source_files        = 'Omise-iOS_SDK/Omise-iOS/OmiseLib/*.{h,m}'
+  s.public_header_files = 'Omise-iOS_SDK/Omise-iOS/OmiseLib/*.h'
+  s.frameworks = ['UIKit']
+end


### PR DESCRIPTION
This library [is already available on CocoaPods][1], but it wasn't documented. Manually copying dependency files into a project where less experienced/disciplined developers are tempted to edit the source code is the way of the cavemen, let's put the pod info in the README so people can evolve :wink: 

It is common and helpful practice to track a library's podspec in the project Git repository. This allows users to do something like this if you have merged a fix that they need to Git master, but haven't pushed a numbered version release to CocoaPods yet that they can get with a normal `pod update omise-ios`:

    pod 'omise-ios', :git => 'https://github.com/omise/omise-ios.git'

I created a podspec in the repo where I mostly copied data from [the one already in the CocoaPods repository][2]. This spec file passes `pod lib lint`.

I also added a separate MIT `LICENSE` file in the repo, since that is also a common convention that developers often look for in a project. The license type in the current published podspec is misspelled as "MTI", so the CocoaPods web page isn't generating a link to the MIT license as it normally would.

[1]: https://cocoapods.org/pods/omise-ios
[2]: https://github.com/CocoaPods/Specs/blob/master/Specs/omise-ios/1.0.1/omise-ios.podspec.json