### PR TITLE
Added: Objective-C support for Omise iOS SDK

### DIFF
--- a/OmiseSDK.xcodeproj/project.pbxproj
+++ b/OmiseSDK.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		2259310F1CE3210700841B86 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				CLASSPREFIX = OMS;
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = Omise;

--- a/OmiseSDK/CardBrand.swift
+++ b/OmiseSDK/CardBrand.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum CardBrand {
+@objc(OMSCardBrand) public enum CardBrand: Int {
     public static let all: [CardBrand] = [
         AMEX,
         Diners,
@@ -63,3 +63,17 @@ public enum CardBrand {
         }
     }
 }
+
+
+@objc(OMSCardBrandHelper) public final class __OMSCardBrand: NSObject {
+    @objc(patternForBrand:) public static func __patternForBrand(brand: CardBrand) -> String {
+        return brand.pattern
+    }
+    
+    @objc(validLengthsForBrand:) public static func __validLengthsForBrand(brand: CardBrand) -> NSRange {
+        let range = brand.validLengths
+        
+        return NSRange(location: range.start, length: range.end - range.start)
+    }
+}
+

--- a/OmiseSDK/CardNumber.swift
+++ b/OmiseSDK/CardNumber.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public final class CardNumber {
-    public static func normalize(pan: String) -> String {
+@objc(OMSCardNumber) public final class CardNumber: NSObject {
+    @objc public static func normalize(pan: String) -> String {
         return pan.stringByReplacingOccurrencesOfString(
             "[^0-9]",
             withString: "",
@@ -15,7 +15,11 @@ public final class CardNumber {
             .first
     }
     
-    public static func format(pan: String) -> String {
+    @objc(brandForPan:) public static func __brand(pan: String) -> Int {
+        return brand(pan)?.rawValue ?? NSNotFound
+    }
+    
+    @objc public static func format(pan: String) -> String {
         var result = ""
         for (i, digit) in normalize(pan).characters.enumerate() {
             if i > 0 && i % 4 == 0 {
@@ -28,7 +32,7 @@ public final class CardNumber {
         return result
     }
     
-    public static func luhn(pan: String) -> Bool {
+    @objc public static func luhn(pan: String) -> Bool {
         let chars = normalize(pan).characters
         let digits = chars
             .reverse()
@@ -48,7 +52,7 @@ public final class CardNumber {
         return sum % 10 == 0
     }
     
-    public static func validate(pan: String) -> Bool {
+    @objc public static func validate(pan: String) -> Bool {
         let normalized = normalize(pan)
         
         guard let brand = brand(normalized) else { return false }

--- a/OmiseSDK/CreditCardFormController.swift
+++ b/OmiseSDK/CreditCardFormController.swift
@@ -55,7 +55,7 @@ public class CreditCardFormController: UIViewController {
         return formCells[6] as? ConfirmButtonCell
     }
     
-    public init(publicKey: String) {
+    @objc public init(publicKey: String) {
         self.publicKey = publicKey
         super.init(nibName: "CreditCardFormController", bundle: NSBundle(forClass: CreditCardFormController.self))
     }
@@ -207,3 +207,4 @@ extension CreditCardFormController: UITableViewDelegate {
         }
     }
 }
+

--- a/OmiseSDK/OmiseCard.swift
+++ b/OmiseSDK/OmiseCard.swift
@@ -1,19 +1,57 @@
 import Foundation
 
-public class OmiseCard: NSObject {
-    public var cardId: String?
-    public var livemode: Bool?
-    public var location: String?
-    public var country: String?
-    public var city: String?
-    public var postalCode: String?
-    public var financing: String?
-    public var lastDigits: String?
-    public var brand: String?
+@objc(OMSOmiseCard) public class OmiseCard: NSObject {
+    @objc public var cardId: String?
+    @objc public var livemode: Bool = false
+    @objc public var location: String?
+    @objc public var country: String?
+    @objc public var city: String?
+    @objc public var postalCode: String?
+    @objc public var financing: String?
+    @objc public var lastDigits: String?
+    @objc public var brand: String?
     public var expirationMonth: Int?
     public var expirationYear: Int?
-    public var fingerprint: String?
-    public var name: String?
-    public var securityCodeCheck: Bool?
-    public var created: NSDate?
+    @objc public var fingerprint: String?
+    @objc public var name: String?
+    @objc public var securityCodeCheck: Bool = false
+    @objc public var created: NSDate?
 }
+
+extension NSCalendar {
+    class func creditCardInformationCalendar() -> NSCalendar {
+        return NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
+    }
+}
+
+
+extension OmiseCard {
+    @objc(expirationMonth) public var __expirationMonth: Int {
+        get {
+            return expirationMonth ?? NSNotFound
+        }
+        set {
+            let validRange = NSCalendar.creditCardInformationCalendar().maximumRangeOfUnit(NSCalendarUnit.Month)
+            let validMonthRange = validRange.location..<validRange.location.advancedBy(validRange.location)
+            if validMonthRange ~= newValue {
+                expirationMonth = newValue
+            } else {
+                expirationMonth = nil
+            }
+            
+        }
+    }
+    @objc(expirationYear) public var __expirationYear: Int {
+        get {
+            return expirationYear ?? NSNotFound
+        }
+        set {
+            if newValue == NSNotFound {
+                expirationYear = nil
+            } else {
+                expirationYear = newValue
+            }
+        }
+    }
+}
+

--- a/OmiseSDK/OmiseFormAccessoryView.swift
+++ b/OmiseSDK/OmiseFormAccessoryView.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class OmiseFormAccessoryView: UIToolbar {
+@objc(OMSOmiseFormAccessoryView) public class OmiseFormAccessoryView: UIToolbar {
     private var textFields = [UITextField]()
     private var currentTextField: UITextField?
     private var previousButton = UIBarButtonItem()
@@ -29,7 +29,7 @@ public class OmiseFormAccessoryView: UIToolbar {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func attachToTextFields(textFields: [UITextField], inViewController viewController: UIViewController) {
+    @objc public func attachToTextFields(textFields: [UITextField], inViewController viewController: UIViewController) {
         self.textFields = textFields
         
         let spacer = UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: nil, action: nil)

--- a/OmiseSDK/OmiseJsonParser.swift
+++ b/OmiseSDK/OmiseJsonParser.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-public final class OmiseJsonParser: NSObject {
-    public static let dateFormatter: NSDateFormatter = {
+@objc(OMSOmiseJsonParser) public final class OmiseJsonParser: NSObject {
+    @objc public static let dateFormatter: NSDateFormatter = {
         let formatter = NSDateFormatter()
         formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         return formatter
     }()
     
-    public static func parseToken(data: NSData) throws -> OmiseToken {
+    @objc public static func parseToken(data: NSData) throws -> OmiseToken {
         let dict = try parseJSON(data)
         guard dict["object"] as? String == "token" else {
             throw OmiseError.Unexpected(message: "Bad JSON response.", underlying: nil)
@@ -19,7 +19,7 @@ public final class OmiseJsonParser: NSObject {
         
         let card = OmiseCard()
         card.cardId = cardDict["id"] as? String
-        card.livemode = cardDict["livemode"] as? Bool
+        card.livemode = cardDict["livemode"] as? Bool ?? false
         card.location = cardDict["location"] as? String
         card.country = cardDict["country"] as? String
         card.city = cardDict["city"] as? String
@@ -31,14 +31,14 @@ public final class OmiseJsonParser: NSObject {
         card.expirationYear = cardDict["expiration_year"] as? Int
         card.fingerprint = cardDict["fingerprint"] as? String
         card.name = cardDict["name"] as? String
-        card.securityCodeCheck = cardDict["security_code_check"] as? Bool
+        card.securityCodeCheck = cardDict["security_code_check"] as? Bool ?? false
         card.created = parseJSONDate(cardDict["created"] as? String)
         
         let token = OmiseToken()
         token.tokenId = dict["id"] as? String
-        token.livemode = dict["livemode"] as? Bool
+        token.livemode = dict["livemode"] as? Bool ?? false
         token.location = dict["location"] as? String
-        token.used = dict["used"] as? Bool
+        token.used = dict["used"] as? Bool ?? false
         token.card = card
         token.created = parseJSONDate(dict["created"] as? String)
         
@@ -58,6 +58,10 @@ public final class OmiseJsonParser: NSObject {
         }
         
         return OmiseError.API(code: code, message: message, location: location)
+    }
+    
+    @objc(parseError:error:) public static func __parseError(data: NSData) throws -> NSError {
+        return try parseError(data).nsError
     }
     
     private static func parseJSON(data: NSData) throws -> NSDictionary {

--- a/OmiseSDK/OmiseToken.swift
+++ b/OmiseSDK/OmiseToken.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-public class OmiseToken: NSObject {
-    public var tokenId: String?
-    public var livemode: Bool?
-    public var location: String?
-    public var used: Bool?
-    public var card: OmiseCard?
-    public var created: NSDate?
+@objc(OMSOmiseToken) public class OmiseToken: NSObject {
+    @objc public var tokenId: String?
+    @objc public var livemode: Bool = false
+    @objc public var location: String?
+    @objc public var used: Bool = false
+    @objc public var card: OmiseCard?
+    @objc public var created: NSDate?
 }
+

--- a/OmiseSDK/OmiseTokenRequest.swift
+++ b/OmiseSDK/OmiseTokenRequest.swift
@@ -5,23 +5,29 @@ public protocol OmiseTokenRequestDelegate {
     func tokenRequest(request: OmiseTokenRequest, didFailWithError error: ErrorType)
 }
 
+@objc public protocol OMSOmiseTokenRequestDelegate {
+    func tokenRequest(request: OmiseTokenRequest, didSucceedWithToken token: OmiseToken)
+    func tokenRequest(request: OmiseTokenRequest, didFailWithError error: NSError)
+}
+
 public enum OmiseTokenRequestResult {
     case Succeed(token: OmiseToken)
     case Fail(error: ErrorType)
 }
 
-public class OmiseTokenRequest: NSObject {
+
+@objc(OMSOmiseTokenRequest) public class OmiseTokenRequest: NSObject {
     public typealias Callback = (OmiseTokenRequestResult) -> ()
     
-    public let name: String
-    public let number: String
-    public let expirationMonth: Int
-    public let expirationYear: Int
-    public let securityCode: String
-    public let city: String?
-    public let postalCode: String?
+    @objc public let name: String
+    @objc public let number: String
+    @objc public let expirationMonth: Int
+    @objc public let expirationYear: Int
+    @objc public let securityCode: String
+    @objc public let city: String?
+    @objc public let postalCode: String?
     
-    public init(name: String, number: String, expirationMonth: Int, expirationYear: Int,
+    @objc public init(name: String, number: String, expirationMonth: Int, expirationYear: Int,
                 securityCode: String, city: String? = nil, postalCode: String? = nil) {
         self.name = name
         self.number = number


### PR DESCRIPTION
This PR is a patch on Omise iOS SDK to support client's Objective-C code. Consist of 

1. Explicitly declared `@objc` keyword on every public APIs.
2. Added Objective-C compatible counterpart methods/types of Objective-C non-compatible public APIs.