### PR TITLE
Drops `Omise` prefix for OBJC exports.

### DIFF
--- a/OmiseSDK.xcodeproj/project.pbxproj
+++ b/OmiseSDK.xcodeproj/project.pbxproj
@@ -193,10 +193,10 @@
 				2220F1A71D0FEE85008CD89F /* OmiseToken.swift */,
 				2220F1A81D0FEE85008CD89F /* OmiseTokenRequest.swift */,
 				2225B3531D0FDD63003EB396 /* Assets.xcassets */,
-				8A5D59831D5317DD005D3346 /* OmiseSDK.storyboard */,
 				9864064B1CFEA820004BCF51 /* Cells */,
 				986406361CFEA7EA004BCF51 /* Fields */,
 				981FA5F91D0EDDB0009ECEDC /* Localizable.strings */,
+				8A5D59831D5317DD005D3346 /* OmiseSDK.storyboard */,
 			);
 			path = OmiseSDK;
 			sourceTree = "<group>";

--- a/OmiseSDK/OmiseCard.swift
+++ b/OmiseSDK/OmiseCard.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc(OMSOmiseCard) public class OmiseCard: NSObject {
+@objc(OMSCard) public class OmiseCard: NSObject {
     @objc public var cardId: String?
     @objc public var livemode: Bool = false
     @objc public var location: String?

--- a/OmiseSDK/OmiseFormAccessoryView.swift
+++ b/OmiseSDK/OmiseFormAccessoryView.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc(OMSOmiseFormAccessoryView) public class OmiseFormAccessoryView: UIToolbar {
+@objc(OMSFormAccessoryView) public class OmiseFormAccessoryView: UIToolbar {
     private var textFields = [UITextField]() {
         willSet {
             textFields.forEach { (textField) in

--- a/OmiseSDK/OmiseJsonParser.swift
+++ b/OmiseSDK/OmiseJsonParser.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc(OMSOmiseJsonParser) public final class OmiseJsonParser: NSObject {
+@objc(OMSJSONParser) public final class OmiseJsonParser: NSObject {
     @objc public static let dateFormatter: NSDateFormatter = {
         let formatter = NSDateFormatter()
         formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")

--- a/OmiseSDK/OmiseSDKClient.swift
+++ b/OmiseSDK/OmiseSDKClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-@objc(OMSOmiseSDKClient) public class OmiseSDKClient: NSObject {
+@objc(OMSSDKClient) public class OmiseSDKClient: NSObject {
     let session: NSURLSession
     let queue: NSOperationQueue
     let publicKey: String

--- a/OmiseSDK/OmiseToken.swift
+++ b/OmiseSDK/OmiseToken.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc(OMSOmiseToken) public class OmiseToken: NSObject {
+@objc(OMSToken) public class OmiseToken: NSObject {
     @objc public var tokenId: String?
     @objc public var livemode: Bool = false
     @objc public var location: String?

--- a/OmiseSDK/OmiseTokenRequest.swift
+++ b/OmiseSDK/OmiseTokenRequest.swift
@@ -5,7 +5,7 @@ public protocol OmiseTokenRequestDelegate {
     func tokenRequest(request: OmiseTokenRequest, didFailWithError error: ErrorType)
 }
 
-@objc public protocol OMSOmiseTokenRequestDelegate {
+@objc public protocol OMSTokenRequestDelegate {
     func tokenRequest(request: OmiseTokenRequest, didSucceedWithToken token: OmiseToken)
     func tokenRequest(request: OmiseTokenRequest, didFailWithError error: NSError)
 }
@@ -16,7 +16,7 @@ public enum OmiseTokenRequestResult {
 }
 
 
-@objc(OMSOmiseTokenRequest) public class OmiseTokenRequest: NSObject {
+@objc(OMSTokenRequest) public class OmiseTokenRequest: NSObject {
     public typealias Callback = (OmiseTokenRequestResult) -> ()
     
     @objc public let name: String


### PR DESCRIPTION
Since `OMS` already provides namespace and shorthand for `Omise`.