### PR TITLE
Fixed: Build failed after merge `dropping Omise prefix in type name`

### DIFF
--- a/OmiseSDK/OmiseSDKClient.swift
+++ b/OmiseSDK/OmiseSDKClient.swift
@@ -85,7 +85,7 @@ import UIKit
         }
     }
     
-    @objc(sendRequest:delegate:) public func __send(request: OmiseTokenRequest, delegate: OMSOmiseTokenRequestDelegate?) {
+    @objc(sendRequest:delegate:) public func __send(request: OmiseTokenRequest, delegate: OMSTokenRequestDelegate?) {
         send(request) { (result) in
             switch result {
             case let .Succeed(token):


### PR DESCRIPTION
We have a build failure after merge the `dropping @objc Omise prefix`.