### PR TITLE
Fixed: Form doesn't update after collecting data from Card.io

### DIFF
--- a/OmiseSDK/CreditCardFormController.swift
+++ b/OmiseSDK/CreditCardFormController.swift
@@ -133,11 +133,7 @@ public class CreditCardFormController: UITableViewController {
     }
     
     @objc private func fieldDidChange(sender: AnyObject) {
-        validateForm()
-        
-        if let cardNumberField = sender as? CardNumberTextField {
-            formHeaderView?.setCardBrand(cardNumberField.cardBrand)
-        }
+        updateSupplementaryUI(includesCardBrand: sender === cardNumberTextField)
     }
     
     @objc private func keyboardWillAppear(notification: NSNotification){
@@ -169,9 +165,17 @@ public class CreditCardFormController: UITableViewController {
         tableView.endUpdates()
     }
     
-    private func validateForm() {
-        let valid = formFields.reduce(true) { (valid, field) -> Bool in valid && field.isValid }
-        confirmButtonCell?.userInteractionEnabled = valid
+    private func updateSupplementaryUI(includesCardBrand includesCardBrand: Bool = false) {
+        func validateForm() {
+            let valid = formFields.reduce(true) { (valid, field) -> Bool in valid && field.isValid }
+            confirmButtonCell?.userInteractionEnabled = valid
+        }
+        
+        validateForm()
+        
+        if includesCardBrand {
+            formHeaderView?.setCardBrand(cardNumberTextField.cardBrand)
+        }
     }
     
     private func requestToken() {
@@ -281,6 +285,8 @@ extension CreditCardFormController: CardIOPaymentViewControllerDelegate {
         if 1...12 ~= cardInfo.expiryMonth && cardInfo.expiryYear > 0 {
             expiryDateTextField.text = String(format: "%02d/%d", cardInfo.expiryMonth, cardInfo.expiryYear - 2000)
         }
+        
+        updateSupplementaryUI(includesCardBrand: true)
         
         dismissViewControllerAnimated(true, completion: { _ in
             if self.cardNameTextField.text?.isEmpty ?? true {

--- a/OmiseSDK/CreditCardFormController.swift
+++ b/OmiseSDK/CreditCardFormController.swift
@@ -133,7 +133,7 @@ public class CreditCardFormController: UITableViewController {
     }
     
     @objc private func fieldDidChange(sender: AnyObject) {
-        updateSupplementaryUI(includesCardBrand: sender === cardNumberTextField)
+        updateSupplementaryUI()
     }
     
     @objc private func keyboardWillAppear(notification: NSNotification){
@@ -165,17 +165,11 @@ public class CreditCardFormController: UITableViewController {
         tableView.endUpdates()
     }
     
-    private func updateSupplementaryUI(includesCardBrand includesCardBrand: Bool = false) {
-        func validateForm() {
-            let valid = formFields.reduce(true) { (valid, field) -> Bool in valid && field.isValid }
-            confirmButtonCell?.userInteractionEnabled = valid
-        }
+    private func updateSupplementaryUI() {
+        let valid = formFields.reduce(true) { (valid, field) -> Bool in valid && field.isValid }
+        confirmButtonCell?.userInteractionEnabled = valid
         
-        validateForm()
-        
-        if includesCardBrand {
-            formHeaderView?.setCardBrand(cardNumberTextField.cardBrand)
-        }
+        formHeaderView?.setCardBrand(cardNumberTextField.cardBrand)
     }
     
     private func requestToken() {
@@ -286,7 +280,7 @@ extension CreditCardFormController: CardIOPaymentViewControllerDelegate {
             expiryDateTextField.text = String(format: "%02d/%d", cardInfo.expiryMonth, cardInfo.expiryYear - 2000)
         }
         
-        updateSupplementaryUI(includesCardBrand: true)
+        updateSupplementaryUI()
         
         dismissViewControllerAnimated(true, completion: { _ in
             if self.cardNameTextField.text?.isEmpty ?? true {

--- a/OmiseSDK/OmiseTextField.swift
+++ b/OmiseSDK/OmiseTextField.swift
@@ -19,6 +19,9 @@ public class OmiseTextField: UITextField {
         didSet {
             // UITextField doesn't send editing changed control event when we set its text property
             textDidChange()
+            if !isFirstResponder() {
+                textColor = isValid ? .blackColor() : .redColor();
+            }
         }
     }
     


### PR DESCRIPTION
This PR fixed some issues about the credit card form doesn't update after collecting data from Card.io

1. Card network logos don't update to tell the collected card's network
2. If user tap the text field and keyboard shows up and then user uses card.io feature, when it comes back to our form, that text field will display red text color even though the card information is valid.