### PR TITLE
Mark objc for omise textfield

### DIFF
--- a/OmiseSDK/CardCVVTextField.swift
+++ b/OmiseSDK/CardCVVTextField.swift
@@ -3,7 +3,7 @@ import UIKit
 
 
 /// UITextField subclass for entering card's CVV number.
-public class CardCVVTextField: OmiseTextField {
+@objc public class CardCVVTextField: OmiseTextField {
     private let validLengths = 3...4
     
     /// Boolean indicating wether current input is valid or not.

--- a/OmiseSDK/CardExpiryDatePicker.swift
+++ b/OmiseSDK/CardExpiryDatePicker.swift
@@ -3,7 +3,7 @@ import Foundation
 // TODO: 👇 only the  data source and delegate needed, we don't need this class.
 
 /// UIPickerView subclass pre-configured for picking card expiration month and year.
-public final class CardExpiryDatePicker: UIPickerView {
+@objc public final class CardExpiryDatePicker: UIPickerView {
     fileprivate static let maximumYear = 21
     fileprivate static let monthPicker = 0
     fileprivate static let yearPicker = 1

--- a/OmiseSDK/CardExpiryDateTextField.swift
+++ b/OmiseSDK/CardExpiryDateTextField.swift
@@ -4,7 +4,7 @@ import UIKit
 
 /// UITextField subclass used for entering card's expiry date.
 /// `CardExpiryDatePicker` will be set as the default input view.
-public class CardExpiryDateTextField: OmiseTextField {
+@objc public class CardExpiryDateTextField: OmiseTextField {
     private let maxCreditCardAge = 21
     private let expirationRx = { () -> NSRegularExpression in
         guard let rx = try? NSRegularExpression(pattern: "^(\\d{1,2})/(\\d{1,2})$", options: []) else {

--- a/OmiseSDK/CardExpiryDateTextField.swift
+++ b/OmiseSDK/CardExpiryDateTextField.swift
@@ -13,11 +13,12 @@ import UIKit
         
         return rx
     }()
-  
-    /// Currently selected month, `nil` if no month has been selected.
-    public var selectedMonth: Int? = nil
-    /// Currently selected year, `nil` if no year has been selected.
-    public var selectedYear: Int? = nil
+    
+    /// Currently selected month, `0` if no month has been selected.
+    public var selectedMonth: Int = 0
+    
+    /// Currently selected year, `0` if no year has been selected.
+    public var selectedYear: Int = 0
     
     /// Boolean indicating wether current input is valid or not.
     public override var isValid: Bool {
@@ -25,14 +26,14 @@ import UIKit
         let calendar = Calendar(identifier: Calendar.Identifier.gregorian)
         let thisMonth = calendar.component(.month, from: now)
         let thisYear = calendar.component(.year, from: now)
-        guard let year = self.selectedYear, let month = self.selectedMonth else {
+        guard self.selectedYear != 0, self.selectedMonth != 0 else {
             return false
         }
         
-        if (year == thisYear) {
-            return thisMonth <= month
+        if (self.selectedYear == thisYear) {
+            return thisMonth <= self.selectedMonth
         } else {
-            return thisYear < year
+            return thisYear < self.selectedYear
         }
     }
     
@@ -66,15 +67,15 @@ import UIKit
         let text = self.text ?? ""
         let range = NSRange(location: 0, length: text.characters.count)
         guard let match = expirationRx.firstMatch(in: text, options: [], range: range), match.numberOfRanges >= 3 else {
-            selectedMonth = nil
-            selectedYear = nil
+            selectedMonth = 0
+            selectedYear = 0
             return
         }
         
         let monthText = textInRange(match.rangeAt(1))
         let yearText = textInRange(match.rangeAt(2))
-        selectedMonth = Int(monthText)
-        selectedYear = Int(yearText)?.advanced(by: 2000)
+        selectedMonth = Int(monthText) ?? 0
+        selectedYear = Int(yearText)?.advanced(by: 2000) ?? 0
     }
     
     private func textInRange(_ range: NSRange) -> String {

--- a/OmiseSDK/CardExpiryDateTextField.swift
+++ b/OmiseSDK/CardExpiryDateTextField.swift
@@ -14,11 +14,17 @@ import UIKit
         return rx
     }()
     
-    /// Currently selected month, `0` if no month has been selected.
-    public var selectedMonth: Int = 0
+    /// Currently selected month, `nil` if no month has been selected.
+    public var selectedMonth: Int? = nil
+    @objc(selectedMonth) public var __selectedMonth: Int {
+        return selectedMonth ?? 0
+    }
     
-    /// Currently selected year, `0` if no year has been selected.
-    public var selectedYear: Int = 0
+    /// Currently selected year, `nil` if no year has been selected.
+    public var selectedYear: Int? = nil
+    @objc(selectedYear) public var __selectedYear: Int {
+        return selectedYear ?? 0
+    }
     
     /// Boolean indicating wether current input is valid or not.
     public override var isValid: Bool {
@@ -26,14 +32,14 @@ import UIKit
         let calendar = Calendar(identifier: Calendar.Identifier.gregorian)
         let thisMonth = calendar.component(.month, from: now)
         let thisYear = calendar.component(.year, from: now)
-        guard self.selectedYear != 0, self.selectedMonth != 0 else {
+        guard let year = self.selectedYear, let month = self.selectedMonth else {
             return false
         }
         
-        if (self.selectedYear == thisYear) {
-            return thisMonth <= self.selectedMonth
+        if (year == thisYear) {
+            return thisMonth <= month
         } else {
-            return thisYear < self.selectedYear
+            return thisYear < year
         }
     }
     
@@ -67,15 +73,15 @@ import UIKit
         let text = self.text ?? ""
         let range = NSRange(location: 0, length: text.characters.count)
         guard let match = expirationRx.firstMatch(in: text, options: [], range: range), match.numberOfRanges >= 3 else {
-            selectedMonth = 0
-            selectedYear = 0
+            selectedMonth = nil
+            selectedYear = nil
             return
         }
         
         let monthText = textInRange(match.rangeAt(1))
         let yearText = textInRange(match.rangeAt(2))
-        selectedMonth = Int(monthText) ?? 0
-        selectedYear = Int(yearText)?.advanced(by: 2000) ?? 0
+        selectedMonth = Int(monthText)
+        selectedYear = Int(yearText)?.advanced(by: 2000)
     }
     
     private func textInRange(_ range: NSRange) -> String {

--- a/OmiseSDK/CardExpiryDateTextField.swift
+++ b/OmiseSDK/CardExpiryDateTextField.swift
@@ -15,9 +15,9 @@ import UIKit
     }()
   
     /// Currently selected month, `nil` if no month has been selected.
-    public private(set) var selectedMonth: Int? = nil
+    public var selectedMonth: Int? = nil
     /// Currently selected year, `nil` if no year has been selected.
-    public private(set) var selectedYear: Int? = nil
+    public var selectedYear: Int? = nil
     
     /// Boolean indicating wether current input is valid or not.
     public override var isValid: Bool {

--- a/OmiseSDK/CardExpiryDateTextField.swift
+++ b/OmiseSDK/CardExpiryDateTextField.swift
@@ -15,13 +15,13 @@ import UIKit
     }()
     
     /// Currently selected month, `nil` if no month has been selected.
-    public var selectedMonth: Int? = nil
+    public private(set) var selectedMonth: Int? = nil
     @objc(selectedMonth) public var __selectedMonth: Int {
         return selectedMonth ?? 0
     }
     
     /// Currently selected year, `nil` if no year has been selected.
-    public var selectedYear: Int? = nil
+    public private(set) var selectedYear: Int? = nil
     @objc(selectedYear) public var __selectedYear: Int {
         return selectedYear ?? 0
     }

--- a/OmiseSDK/CardNameTextField.swift
+++ b/OmiseSDK/CardNameTextField.swift
@@ -3,7 +3,7 @@ import UIKit
 
 
 /// UITextField subclass for entering card holder's name.
-public class CardNameTextField: OmiseTextField {
+@objc public class CardNameTextField: OmiseTextField {
     /// Boolean indicating wether current input is valid or not.
     public override var isValid: Bool {
         return !(text ?? "").isEmpty

--- a/OmiseSDK/CardNumberTextField.swift
+++ b/OmiseSDK/CardNumberTextField.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// UITextField subclass for entering the credit card number.
 /// Automatically formats entered number into groups of four.
-public class CardNumberTextField: OmiseTextField {
+@objc public class CardNumberTextField: OmiseTextField {
     private var updatingText = false
     private let maxLength = 19
     

--- a/OmiseSDK/OmiseTextField.swift
+++ b/OmiseSDK/OmiseTextField.swift
@@ -10,7 +10,7 @@ public protocol OmiseTextFieldValidationDelegate {
 
 
 /// Base UITextField subclass for SDK's text fields.
-public class OmiseTextField: UITextField {
+@objc public class OmiseTextField: UITextField {
     public private(set) var previousText: String?
     
     public override var text: String? {


### PR DESCRIPTION
This PR will let CardExpiryDateTextField and other fields support for Objective-C