### PR TITLE
Support additional range of 2-series numbers for Mastercard

### DIFF
--- a/OmiseSDK/CardBrand.swift
+++ b/OmiseSDK/CardBrand.swift
@@ -35,7 +35,7 @@ import Foundation
         case .Visa:
             return "^4"
         case .MasterCard:
-            return "^5[1-5]"
+            return "^(5[1-5]|2(2(2[1-9]|[3-9])|[3-6]|7(0|1|20)))"
         case .Maestro:
             return "^(5018|5020|5038|6304|6759|676[1-3])"
         case .Discover:

--- a/OmiseSDKTests/CardNumberTest.swift
+++ b/OmiseSDKTests/CardNumberTest.swift
@@ -16,14 +16,17 @@ class CardNumberTest: SDKTestCase {
     }
     
     func testBrand() {
-        let tests: [CardBrand: String] = [
-            .Visa: "4242424242424242",
-            .MasterCard: "5454545454545454",
-            .JCB: "3566111111111113",
+        let tests: [[CardBrand: String]] = [
+            [.Visa: "4242424242424242"],
+            [.JCB: "3566111111111113"],
+            [.MasterCard: "5454545454545454"],
+            [.MasterCard: "2221001234123456"]
         ]
         
-        tests.forEach { (brand, number) in
-            XCTAssertEqual(brand, CardNumber.brand(of: number))
+        tests.forEach { cards in
+            cards.forEach({ (brand, number) in
+                XCTAssertEqual(brand, CardNumber.brand(of: number))
+            })
         }
     }
     


### PR DESCRIPTION
From the #56 issue, this pr update regular expression for support range of 2-series numbers for Mastercard.

References : 
- https://www.mastercard.us/en-us/issuers/get-support/2-series-bin-expansion.html
- https://www.bincodes.com/bin-list/