### PR TITLE
Check number characters in CardNameTextField before return valid case

### DIFF
--- a/OmiseSDK/CardNameTextField.swift
+++ b/OmiseSDK/CardNameTextField.swift
@@ -7,7 +7,7 @@ import UIKit
 public class CardNameTextField: OmiseTextField {
     /// Boolean indicating wether current input is valid or not.
     public override var isValid: Bool {
-        return !text.isNilOrEmpty
+        return !text.isNilOrEmpty && (text ?? "").rangeOfCharacter(from: .decimalDigits) == nil
     }
     
     override public init(frame: CGRect) {


### PR DESCRIPTION
- For preventing user error case. We found some user input other data on the name field.