### PR TITLE
Add missing payment methods to capability API

### DIFF
--- a/OmiseSDK/Capability.swift
+++ b/OmiseSDK/Capability.swift
@@ -67,6 +67,7 @@ extension Capability {
             case paynow
             case truemoney
             case points(PaymentInformation.Points)
+            case eContext
             case unknownSource(String, configurations: [String: Any])
         }
     }
@@ -101,6 +102,8 @@ extension Capability.Backend.Payment {
         case (.promptpay, .promptpay), (.paynow, .paynow):
             return true
         case (.truemoney, .truemoney):
+            return true
+        case (.eContext, .eContext):
             return true
         case (.points(let lhsValue), .points(let rhsValue)):
             return lhsValue == rhsValue
@@ -180,6 +183,8 @@ extension Capability.Backend {
             self.payment = .points(.citiPoints)
         case .source(.billPaymentTescoLotus):
             self.payment = .billPayment(.tescoLotus)
+        case .source(.eContext):
+            self.payment = .eContext
         case .source(let value):
             let configurations = try container.decodeJSONDictionary()
             self.payment = .unknownSource(value.rawValue, configurations: configurations)
@@ -201,7 +206,7 @@ extension Capability.Backend {
         case .unknownSource(_, configurations: let configurations):
             try encoder.encodeJSONDictionary(configurations)
             try container.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
-        case .internetBanking, .alipay, .promptpay, .paynow, .truemoney, .points, .billPayment:
+        case .internetBanking, .alipay, .promptpay, .paynow, .truemoney, .points, .billPayment, .eContext:
             try container.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
         }
     }
@@ -259,6 +264,8 @@ extension Capability.Backend {
                 self = .source(.trueMoney)
             case .points(let points):
                 self = .source(OMSSourceTypeValue(points.type))
+            case .eContext:
+                self = .source(.eContext)
             }
         }
         

--- a/OmiseSDK/Capability.swift
+++ b/OmiseSDK/Capability.swift
@@ -61,6 +61,7 @@ extension Capability {
             case card(Set<CardBrand>)
             case installment(PaymentInformation.Installment.Brand, availableNumberOfTerms: IndexSet)
             case internetBanking(PaymentInformation.InternetBanking)
+            case billPayment(PaymentInformation.BillPayment)
             case alipay
             case promptpay
             case paynow
@@ -106,6 +107,8 @@ extension Capability.Backend.Payment {
         case (.installment(let lhsValue), .installment(let rhsValue)):
             return lhsValue == rhsValue
         case (.internetBanking(let lhsValue), .internetBanking(let rhsValue)):
+            return lhsValue == rhsValue
+        case (.billPayment(let lhsValue), .billPayment(let rhsValue)):
             return lhsValue == rhsValue
         default:
             return false
@@ -175,6 +178,8 @@ extension Capability.Backend {
             self.payment = .truemoney
         case .source(.pointsCiti):
             self.payment = .points(.citiPoints)
+        case .source(.billPaymentTescoLotus):
+            self.payment = .billPayment(.tescoLotus)
         case .source(let value):
             let configurations = try container.decodeJSONDictionary()
             self.payment = .unknownSource(value.rawValue, configurations: configurations)
@@ -196,7 +201,7 @@ extension Capability.Backend {
         case .unknownSource(_, configurations: let configurations):
             try encoder.encodeJSONDictionary(configurations)
             try container.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
-        case .internetBanking, .alipay, .promptpay, .paynow, .truemoney, .points:
+        case .internetBanking, .alipay, .promptpay, .paynow, .truemoney, .points, .billPayment:
             try container.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
         }
     }
@@ -242,6 +247,8 @@ extension Capability.Backend {
                 self = .source(OMSSourceTypeValue(brand.type))
             case .internetBanking(let banking):
                 self = .source(OMSSourceTypeValue(banking.type))
+            case .billPayment(let billPayment):
+                self = .source(OMSSourceTypeValue(billPayment.type))
             case .unknownSource(let sourceType, configurations: _):
                 self = .source(.init(sourceType))
             case .promptpay:

--- a/OmiseSDK/Compatability/OmiseCapability.swift
+++ b/OmiseSDK/Compatability/OmiseCapability.swift
@@ -68,6 +68,9 @@ class __OmiseCapabilitySourceBackendPayment: __OmiseCapabilityBackendPayment {
     static let cityPointsSourceBackendPayment =
     __OmiseCapabilitySourceBackendPayment(sourceType: OMSSourceTypeValue.pointsCiti)
     
+    static let eContextSourceBackendPayment =
+    __OmiseCapabilitySourceBackendPayment(sourceType: OMSSourceTypeValue.eContext)
+    
     static func makeInternetBankingSourceBackendPayment(
         bank: PaymentInformation.InternetBanking
         ) -> __OmiseCapabilitySourceBackendPayment {
@@ -117,6 +120,8 @@ extension __OmiseCapabilityBackendPayment {
             return __OmiseCapabilitySourceBackendPayment.truemoneySourceBackendPayment
         case .points(let points):
             return __OmiseCapabilitySourceBackendPayment(sourceType: OMSSourceTypeValue(points.type))
+        case .eContext:
+            return __OmiseCapabilitySourceBackendPayment.eContextSourceBackendPayment
         case .unknownSource(let type, let configurations):
             return __OmiseCapabilityUnknownSourceBackendPayment(sourceType: type, parameters: configurations)
         }

--- a/OmiseSDK/Compatability/OmiseCapability.swift
+++ b/OmiseSDK/Compatability/OmiseCapability.swift
@@ -105,6 +105,8 @@ extension __OmiseCapabilityBackendPayment {
             )
         case .internetBanking(let bank):
             return __OmiseCapabilitySourceBackendPayment.makeInternetBankingSourceBackendPayment(bank: bank)
+        case .billPayment(let billPayment):
+            return __OmiseCapabilitySourceBackendPayment(sourceType: OMSSourceTypeValue(billPayment.type))
         case .alipay:
             return __OmiseCapabilitySourceBackendPayment.alipaySourceBackendPayment
         case .promptpay:

--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -297,6 +297,8 @@ class PaymentChooserViewController: AdaptableStaticTableViewController<PaymentCh
                 return OMSSourceTypeValue(brand.type)
             case .internetBanking(let bank):
                 return OMSSourceTypeValue(bank.type)
+            case .billPayment(let billPayment):
+                return OMSSourceTypeValue(billPayment.type)
             case .card, .unknownSource:
                 return nil
             }

--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -299,6 +299,8 @@ class PaymentChooserViewController: AdaptableStaticTableViewController<PaymentCh
                 return OMSSourceTypeValue(bank.type)
             case .billPayment(let billPayment):
                 return OMSSourceTypeValue(billPayment.type)
+            case .eContext:
+                return OMSSourceTypeValue.eContext
             case .card, .unknownSource:
                 return nil
             }


### PR DESCRIPTION
**1. Objective**

When the capability API is selected as the source of payment methods all payment methods from the API should be shown in the PaymentChooser. This is not the case for Tesco Lotus Bill Payment and eContext.

In this PR this should be fixed.

**2. Description of change**

Added Tesco Lotus Bill Payment and eContext as payment methods used from the capability API.

**3. Quality assurance**

When the capability API is selected as the source of payment methods the payment methods shown in the PaymentChooser should match the payment methods received from the Capability API.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal