### PR TITLE
Fix error text when amount is too high or too low

### DIFF
--- a/OmiseSDK/Globals.swift
+++ b/OmiseSDK/Globals.swift
@@ -574,7 +574,7 @@ extension OmiseError {
                         let preferredErrorDescriptionFormat = NSLocalizedString(
                             "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion",
                             tableName: "Error", bundle: Bundle.omiseSDKBundle,
-                            value: "The payment amount is too high. Please make a payment with a lower amount",
+                            value: "The payment amount is too low. Please make a payment with a higher amount.",
                             comment: "The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred"
                         )
                         let formatter = NumberFormatter.makeAmountFormatter(for: currency)
@@ -585,7 +585,7 @@ extension OmiseError {
                         return NSLocalizedString(
                             "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.recovery-suggestion",
                             tableName: "Error", bundle: Bundle.omiseSDKBundle,
-                            value: "The payment amount is too high. Please make a payment with a lower amount",
+                            value: "The payment amount is too low. Please make a payment with a higher amount.",
                             comment: "The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.without-valid-amount` from the backend has occurred"
                         )
                     }
@@ -594,7 +594,7 @@ extension OmiseError {
                         let preferredErrorDescriptionFormat = NSLocalizedString(
                             "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.recovery-suggestion",
                             tableName: "Error", bundle: Bundle.omiseSDKBundle,
-                            value: "The payment amount is too high. Please make a payment with a higher amount.",
+                            value: "The payment amount is too high. Please make a payment with a lower amount.",
                             comment: "The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-greater-than-valid-amount.with-valid-amount` from the backend has occurred"
                         )
                         let formatter = NumberFormatter.makeAmountFormatter(for: currency)
@@ -605,7 +605,7 @@ extension OmiseError {
                         return NSLocalizedString(
                             "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.recovery-suggestion",
                             tableName: "Error", bundle: Bundle.omiseSDKBundle,
-                            value: "The payment amount is too high. Please make a payment with a higher amount.",
+                            value: "The payment amount is too high. Please make a payment with a lower amount.",
                             comment: "The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-greater-than-valid-amount.without-valid-amount` from the backend has occurred"
                         )
                     }

--- a/OmiseSDK/en.lproj/Error.strings
+++ b/OmiseSDK/en.lproj/Error.strings
@@ -182,25 +182,25 @@
 "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.message" = "Amount is greater than the valid amount of %@";
 
 /* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-greater-than-valid-amount.with-valid-amount` from the backend has occurred */
-"payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.recovery-suggestion" = "The payment amount is too high. Please make a payment with a higher amount.";
+"payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.recovery-suggestion" = "The payment amount is too high. Please make a payment with a lower amount.";
 
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-greater-than-valid-amount.without-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.message" = "Amount is greater than the valid amount";
 
 /* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-greater-than-valid-amount.without-valid-amount` from the backend has occurred */
-"payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.recovery-suggestion" = "The payment amount is too high. Please make a payment with a higher amount.";
+"payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.recovery-suggestion" = "The payment amount is too high. Please make a payment with a lower amount.";
 
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.message" = "Amount is less than the valid amount of %@";
 
 /* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred */
-"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion" = "The payment amount is too high. Please make a payment with a lower amount";
+"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion" = "The payment amount is too low. Please make a payment with a higher amount.";
 
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-less-than-valid-amount.without-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.message" = "Amount is less than the valid amount";
 
 /* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.without-valid-amount` from the backend has occurred */
-"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.recovery-suggestion" = "The payment amount is too high. Please make a payment with a lower amount";
+"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.recovery-suggestion" = "The payment amount is too low. Please make a payment with a higher amount.";
 
 /* The displaying message showing in the error banner an `Bad request` error with `currency-not-supported` from the backend has occurred */
 "payment-creator.error.api.bad_request.currency-not-supported.message" = "The currency is not supported for this account";

--- a/OmiseSDK/ja.lproj/Error.strings
+++ b/OmiseSDK/ja.lproj/Error.strings
@@ -172,14 +172,28 @@
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-greater-than-valid-amount.with-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.message" = "金額が%@の有効金額を超過しています";
 
+/* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-greater-than-valid-amount.with-valid-amount` from the backend has occurred */
+"payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.recovery-suggestion" = "決済金額が高すぎます。より低額で決済を行ってください。";
+
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-greater-than-valid-amount.without-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.message" = "金額が有効金額を超過しています";
+
+
+/* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-greater-than-valid-amount.without-valid-amount` from the backend has occurred */
+"payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.recovery-suggestion" = "決済金額が高すぎます。より低額で決済を行ってください。";
 
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.message" = "金額が%dの有効金額以下です";
 
+/* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred */
+"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion" = "決済金額が低すぎます。より高額で決済を行ってください。";
+
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-less-than-valid-amount.without-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.message" = "金額が有効金額以下です";
+
+
+/* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.without-valid-amount` from the backend has occurred */
+"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.recovery-suggestion" = "決済金額が低すぎます。より高額で決済を行ってください。";
 
 /* The displaying message showing in the error banner an `Bad request` error with `currency-not-supported` from the backend has occurred */
 "payment-creator.error.api.bad_request.currency-not-supported.message" = "このアカウントでこちらの通貨はサポートされていません";


### PR DESCRIPTION
**1. Objective**

The error messages shown by the SDK when the payment amount is too low or too high are partially mixed up. The Japanese translation for them is missing completely.

**2. Description of change**

Fixed error messages and added Japanese translations.

**3. Quality assurance**

When a payment is done with an amount below or above the limits a correct error message should be presented to the user. This message should be also available in Japanese.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal