### PR TITLE
Fix localization issues

### DIFF
--- a/OmiseSDK/ja.lproj/Error.strings
+++ b/OmiseSDK/ja.lproj/Error.strings
@@ -29,10 +29,10 @@
 "error.api.authentication_failure.recovery-suggestion" = "加盟店までご連絡ください";
 
 /* A default descriptive message representing an `Bad request` error with `amount-is-greater-than-valid-amount.with-valid-amount` from the backend which a merchant may show this message to their user */
-"error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.message" = "金額が%dの有効金額を超過しています";
+"error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.message" = "金額が%@の有効金額を超過しています";
 
 /* A default descriptive message representing an `Bad request` error with `amount-is-greater-than-valid-amount.with-valid-amount` from the backend which a merchant may show this message to their user */
-"error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.recovery-suggestion" = "%d未満の金額でソースを作成してください";
+"error.api.bad_request.amount-is-greater-than-valid-amount.with-valid-amount.recovery-suggestion" = "%@未満の金額でソースを作成してください";
 
 /* A default descriptive message representing an `Bad request` error with `amount-is-greater-than-valid-amount.without-valid-amount` from the backend which a merchant may show this message to their user */
 "error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.message" = "金額が有効金額を超過しています";
@@ -41,7 +41,7 @@
 "error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.recovery-suggestion" = "これより少ない金額でソースを作成してください";
 
 /* A default descriptive message representing an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend which a merchant may show this message to their user */
-"error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion" = "%d以上の金額でソースを作成してください";
+"error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion" = "%@以上の金額でソースを作成してください";
 
 /* A default descriptive message representing an `Bad request` error with `amount-is-less-than-valid-amount.without-valid-amount` from the backend which a merchant may show this message to their user */
 "error.api.bad_request.amount-is-less-than-valid-amount.without-valid-amount.message" = "金額が有効金額以下です";
@@ -183,7 +183,7 @@
 "payment-creator.error.api.bad_request.amount-is-greater-than-valid-amount.without-valid-amount.recovery-suggestion" = "決済金額が高すぎます。より低額で決済を行ってください。";
 
 /* The displaying message showing in the error banner an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred */
-"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.message" = "金額が%dの有効金額以下です";
+"payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.message" = "金額が%@の有効金額以下です";
 
 /* The displaying recovery from error suggestion showing in the error banner in the built-in Payment Creator an `Bad request` error with `amount-is-less-than-valid-amount.with-valid-amount` from the backend has occurred */
 "payment-creator.error.api.bad_request.amount-is-less-than-valid-amount.with-valid-amount.recovery-suggestion" = "決済金額が低すぎます。より高額で決済を行ってください。";

--- a/OmiseSDK/ja.lproj/Localizable.stringsdict
+++ b/OmiseSDK/ja.lproj/Localizable.stringsdict
@@ -14,7 +14,7 @@
 			<string>%d 月々</string>
 		</dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>％＃＠月々@</string>
+		<string>%#@MONTHs@</string>
 	</dict>
 </dict>
 </plist>

--- a/OmiseSDK/th.lproj/Localizable.stringsdict
+++ b/OmiseSDK/th.lproj/Localizable.stringsdict
@@ -14,7 +14,7 @@
 			<string>%d เดือน</string>
 		</dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@เดือน@</string>
+		<string>%#@MONTHs@</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
**1. Objective**

Some localized strings are formatted incorrectly. This results in wrong or missing information.
- The list of available `Installment Term Lengths` is not showing the number of month in Thai and Japanese what makes it impossible to choose one
- Some error messages in Japanese are showing wrong limits in the error reason

**2. Description of change**

- Fixed wrong `NSStringLocalizedFormatKey` in stringsdict
- Replaced `%d` with `%@` when a String should be inserted in the localized string

**3. Quality assurance**

- Installment months should be correctly displayed in Thai and Japanese.
- The amount limits shown in the Japanese error message should match the actual limits

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal