### PR TITLE
Set Card property to an optional value

### DIFF
--- a/OmiseSDK/Compatability/OmiseCard.swift
+++ b/OmiseSDK/Compatability/OmiseCard.swift
@@ -6,67 +6,67 @@ import Foundation
  - seealso: [Cards API](https://www.omise.co/cards-api)
  */
 @objc(OMSCard) public class __OmiseCard: NSObject {
-    private let card: Card
+    private let card: Card?
     /// Card's ID.
     @objc public var cardId: String? {
-        return card.id
+        return card?.id
     }
     /// Boolean flag indicating wether this card is a live card or a test card.
     @objc public var livemode: Bool {
-        return card.isLiveMode
+        return card?.isLiveMode ?? false
     }
     /// ISO3166 Country code based on the card number.
     /// - note: This is informational only and may not always be 100% accurate.
     @objc public var country: String? {
-        return card.countryCode
+        return card?.countryCode
     }
     /// Issuing city.
     /// - note: This is informational only and may not always be 100% accurate.
     @objc public var city: String? {
-        return card.city
+        return card?.city
     }
     /// Postal code.
     @objc public var postalCode: String? {
-        return card.postalCode
+        return card?.postalCode
     }
     /// Credit card financing type. (debit or credit)
     @objc public var financing: String? {
-        return card.financing
+        return card?.financing
     }
     /// Last 4 digits of the card number.
     @objc public var lastDigits: String? {
-        return card.lastDigits
+        return card?.lastDigits
     }
     /// Card brand. (e.g. Visa, Mastercard, ...)
     @objc public var brand: String? {
-        return card.brand
+        return card?.brand
     }
     /// Card expiration month (1-12)
     @objc public var expirationMonth: Int {
-        return card.expirationMonth ?? NSNotFound
+        return card?.expirationMonth ?? NSNotFound
     }
     /// Card expiration year (Gregrorian)
     @objc public var expirationYear: Int {
-        return card.expirationYear ?? NSNotFound
+        return card?.expirationYear ?? NSNotFound
     }
     /// Unique card-based fingerprint. Allows detection of identical cards without
     /// exposing card numbers directly.
     @objc public var fingerprint: String? {
-        return card.fingerprint
+        return card?.fingerprint
     }
     /// Card holder's full name.
     @objc public var name: String? {
-        return card.name
+        return card?.name
     }
     @objc public var securityCodeCheck: Bool {
-        return card.securityCodeCheck
+        return card?.securityCodeCheck ?? false
     }
     /// Card's creation time.
     @objc public var created: Date? {
-        return card.createdDate
+        return card?.createdDate
     }
     
-    init(card: Card) {
+    init(card: Card?) {
         self.card = card
     }
 }

--- a/OmiseSDK/Token.swift
+++ b/OmiseSDK/Token.swift
@@ -102,7 +102,7 @@ public struct Token: CreatableObject {
     public var isUsed: Bool
     
     /// Card that is used for creating this Token
-    public let card: Card
+    public let card: Card?
     
     /// Date that this Token was created
     public let createdDate: Date

--- a/OmiseSDKTests/ClientTestCase.swift
+++ b/OmiseSDKTests/ClientTestCase.swift
@@ -22,9 +22,9 @@ class ClientTestCase: XCTestCase {
             defer { expectation.fulfill() }
             switch result {
             case .success(let token):
-                XCTAssertEqual("4242", token.card.lastDigits)
-                XCTAssertEqual(11, token.card.expirationMonth)
-                XCTAssertEqual(2030, token.card.expirationYear)
+                XCTAssertEqual("4242", token.card?.lastDigits)
+                XCTAssertEqual(11, token.card?.expirationMonth)
+                XCTAssertEqual(2030, token.card?.expirationYear)
             case .failure(let error):
                 XCTFail("Expected succeed request but it failed with \(error)")
             }

--- a/OmiseSDKTests/Fixtures/objects/token_with_empty_card_object.json
+++ b/OmiseSDKTests/Fixtures/objects/token_with_empty_card_object.json
@@ -1,0 +1,11 @@
+{
+  "object": "token",
+  "id": "tokn_test_5086xl7c9k5rnx35qba",
+  "livemode": false,
+  "location": "/tokens/tokn_test_5086xl7c9k5rnx35qba",
+  "created_at": "2019-07-26T05:45:20Z",
+  "used": false,
+  "charge_status": "pending",
+  "card": null
+}
+

--- a/OmiseSDKTests/ModelTestCase.swift
+++ b/OmiseSDKTests/ModelTestCase.swift
@@ -14,8 +14,22 @@ class ModelTestCase: XCTestCase {
         XCTAssertFalse(token.isLiveMode)
         XCTAssertEqual(XCTestCase.dateFromJSONString("2019-07-26T05:45:20Z"), token.createdDate)
         XCTAssertFalse(token.isUsed)
-        XCTAssertEqual("card_test_5086xl7amxfysl0ac5l", token.card.id)
+        XCTAssertEqual("card_test_5086xl7amxfysl0ac5l", token.card?.id)
         XCTAssertEqual(ChargeStatus.unknown, token.chargeStatus)
+    }
+    
+    func testDecodeTokenWithoutCard() throws {
+        let decoder = Client.makeJSONDecoder(for: Request<Token>?.none)
+        let tokenData = XCTestCase.fixturesData(forFilename: "token_with_empty_card_object")
+        let token = try decoder.decode(Token.self, from: tokenData)
+
+        XCTAssertEqual("tokn_test_5086xl7c9k5rnx35qba", token.id)
+        XCTAssertEqual("/tokens/tokn_test_5086xl7c9k5rnx35qba", token.location)
+        XCTAssertFalse(token.isLiveMode)
+        XCTAssertEqual(XCTestCase.dateFromJSONString("2019-07-26T05:45:20Z"), token.createdDate)
+        XCTAssertFalse(token.isUsed)
+        XCTAssertEqual(ChargeStatus.pending, token.chargeStatus)
+        XCTAssertNil(token.card)
     }
     
     func testDecodeCard() throws {


### PR DESCRIPTION
**1. Objective**

- Improve the Token model, Card property can be an optional value. 

**2. Description of change**

- Set `Card` property to an optional value 

**3. Quality assurance**

- Card property in Token can be null. Decoding from an API will correctly and not crash when the Card is empty.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. The priority of change**

Normal