### PR TITLE
Fix tests with @testable import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run xcodebuild with tests
-      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest'
+      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' ENABLE_TESTABILITY=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run xcodebuild with tests
-      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' ENABLE_TESTABILITY=true
+      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' ENABLE_TESTABILITY=yes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run xcodebuild with tests
-      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' ENABLE_TESTABILITY=yes
+      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' ENABLE_TESTABILITY=yes

--- a/OmiseSDKTests/Compatability Suite/OmiseTokenRequestTest.swift
+++ b/OmiseSDKTests/Compatability Suite/OmiseTokenRequestTest.swift
@@ -16,7 +16,7 @@ class OmiseTokenRequestTest: XCTestCase {
             name: "JOHN DOE",
             number: "4242424242424242",
             expirationMonth: 11,
-            expirationYear: 2020,
+            expirationYear: 2022,
             securityCode: "123"
         )
     }
@@ -26,7 +26,7 @@ class OmiseTokenRequestTest: XCTestCase {
             name: "JOHN DOE",
             number: "42424242424242421111", // invalid number
             expirationMonth: 11,
-            expirationYear: 2020,
+            expirationYear: 2022,
             securityCode: "123",
             city: nil,
             postalCode: nil
@@ -48,7 +48,7 @@ class OmiseTokenRequestTest: XCTestCase {
             
             XCTAssertEqual("4242", delegate.token?.card?.lastDigits)
             XCTAssertEqual(11, delegate.token?.card?.expirationMonth)
-            XCTAssertEqual(2020, delegate.token?.card?.expirationYear)
+            XCTAssertEqual(2022, delegate.token?.card?.expirationYear)
         }
     }
     
@@ -60,7 +60,7 @@ class OmiseTokenRequestTest: XCTestCase {
             case .succeed(token: let token):
                 XCTAssertEqual("4242", token.card?.lastDigits)
                 XCTAssertEqual(11, token.card?.expirationMonth)
-                XCTAssertEqual(2020, token.card?.expirationYear)
+                XCTAssertEqual(2022, token.card?.expirationYear)
             case .fail(let error):
                 XCTFail("Expected succeed request but failed with \(error)")
             }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
 [![](https://img.shields.io/badge/email-support-yellow.svg?style=flat-square)](mailto:support@omise.co)
+![CI](https://github.com/omise/omise-ios/workflows/CI/badge.svg?branch=master)
 
 [Omise](https://www.omise.co/) is a payment service provider operating
 in Thailand, Japan, and Singapore. Omise provides a set of APIs that


### PR DESCRIPTION
Tests were failing with this error message.  

```
omise-ios/OmiseSDKTests/CapabilityOperationFixtureTests.swift:2:18: 
  error: module 'OmiseSDK' was not compiled for testing
@testable import OmiseSDK
```

Using `@testable` depends on enabling "testability" in build settings as well.