### PR TITLE
docs: support only iOS 10 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ you can't find an answer there, post a question in our
 ## Requirements
 
 * Omise API public key. [Register for an Omise account](https://dashboard.omise.co/signup) to obtain your API keys.
-* iOS 8 or higher deployment target.
+* iOS 10 or higher deployment target.
 * Xcode 10.0 or higher (Xcode 11 is recommended)
 * Swift 5.0 or higher (Swift 5.1 is recommended)
 * [Carthage](https://github.com/Carthage/Carthage) dependency manager.


### PR DESCRIPTION
- [#116](https://github.com/omise/omise-ios/pull/116) it already drop support for iOS 9
- [#113](https://github.com/omise/omise-ios/pull/113) it already drop support for iOS 8
- And 2 guidelines ([1](https://www.bot.or.th/Thai/AboutBOT/Activities/Documents/MediaBriefing_20122019.pdf), [2](https://www.bot.or.th/Thai/FIPCS/Documents/FOG/2562/ThaiPDF/25620311.pdf)) from Bank of Thailand (BOT) and should not allow to use obsolete operating system (OS) version.