### PR TITLE
Update README, update Carthage build instructions, and quiet test output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run xcodebuild with tests
-      run: xcodebuild test -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' ENABLE_TESTABILITY=yes
+      run: xcodebuild test -quiet -scheme OmiseSDKTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' ENABLE_TESTABILITY=yes

--- a/OmiseSDKTests/PANModelTestCase.swift
+++ b/OmiseSDKTests/PANModelTestCase.swift
@@ -6,7 +6,7 @@ class PANModelTestCase: XCTestCase {
     
     func testCreatePANs() {
         do {
-            let pan = PAN("4242424242424241")
+            let pan = PAN("4242424242424242")
             XCTAssertEqual(pan.pan, "4242424242424242")
         }
         

--- a/OmiseSDKTests/PANModelTestCase.swift
+++ b/OmiseSDKTests/PANModelTestCase.swift
@@ -6,7 +6,7 @@ class PANModelTestCase: XCTestCase {
     
     func testCreatePANs() {
         do {
-            let pan = PAN("4242424242424242")
+            let pan = PAN("4242424242424241")
             XCTAssertEqual(pan.pan, "4242424242424242")
         }
         

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ through your server.
 To get started, add the following line to your `Cartfile`:
 
 ```
-github "omise/omise-ios" ~> 3.0
+github "omise/omise-ios" ~> 4.1
 ```
 
 Then run `carthage update`:
@@ -56,7 +56,7 @@ Then run `carthage update`:
 ``` bash
 $ carthage update
 *** Fetching omise-ios
-*** Checking out omise-ios at "v3.5.0"
+*** Checking out omise-ios at "..."
 *** xcodebuild output can be found in /var/folders/sd/ccsbmstn2vbbqd7nk4fgkd040000gn/T/carthage-xcodebuild.X7ZfYB.log
 *** Building scheme "OmiseSDK" in OmiseSDK.xcodeproj
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ through your server.
 To get started, add the following line to your `Cartfile`:
 
 ```
-github "omise/omise-ios" ~> 4.1
+github "omise/omise-ios" ~> 4.1.0
 ```
 
 Then run `carthage update`:


### PR DESCRIPTION
* Update README to point to latest version of SDK in Carthage instructions
* Make test output quiet (report only errors)
* Use recommended `--use-xcframeworks` flag