### PR TITLE
Change init of payment method installment to public

### DIFF
--- a/OmiseSDK/SourcePaymentMethod.swift
+++ b/OmiseSDK/SourcePaymentMethod.swift
@@ -102,7 +102,7 @@ public enum PaymentInformation: Codable, Equatable {
             }
         }
         
-        init(brand: Brand, numberOfTerms: Int) {
+        public init(brand: Brand, numberOfTerms: Int) {
             self.brand = brand
             self.numberOfTerms = numberOfTerms
         }


### PR DESCRIPTION
**1. Objective**

The initializer of the payment method `Installment` is internal but it should be public.

**2. Description of change**

Changed initializer of payment method `Installment` to public.

**3. Quality assurance**

It should be possible to create a new payment method of type`Installment` :
```
PaymentInformation.Installment(brand: .bay, numberOfTerms: 6)
```

**4. Operations impact**
N/A

**5. Business impact**
N/A

**6. The priority of change**
Normal