### PR TITLE
Fix mobile banking label in dark mode

### DIFF
--- a/OmiseSDK/Resources/Base.lproj/OmiseSDK.storyboard
+++ b/OmiseSDK/Resources/Base.lproj/OmiseSDK.storyboard
@@ -960,6 +960,7 @@
                         <outletCollection property="paymentMethodNameLables" destination="ewt-LA-vRb" collectionClass="NSMutableArray" id="rYn-xG-eTD"/>
                         <outletCollection property="paymentMethodNameLables" destination="zmw-2Y-WAX" collectionClass="NSMutableArray" id="dgu-0i-wQw"/>
                         <outletCollection property="paymentMethodNameLables" destination="3Ch-6f-IHn" collectionClass="NSMutableArray" id="jHo-rX-VF2"/>
+                        <outletCollection property="paymentMethodNameLables" destination="drr-nc-RA8" collectionClass="NSMutableArray" id="13O-qc-zJ5"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zoe-8g-RM3" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
**1. Objective**

For the payment method `Mobile Banking` the text in the `PaymentChooserViewController` is not displayed correctly in dark mode. The text is displayed to dark compared to the other payment methods.

**2. Description of change**

N/A

**3. Quality assurance**

![Simulator Screen Shot - iPhone 12 - 2021-03-26 at 09 04 49](https://user-images.githubusercontent.com/712728/112590699-d9000480-8e35-11eb-99b5-95f78e196df2.png)

**4. Operations impact**
N/A

**5. Business impact**
N/A

**6. The priority of change**
Normal