### PR TITLE
Fix error view in PaymentCreatorController

### DIFF
--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -227,7 +227,6 @@ class PaymentChooserViewController: AdaptableStaticTableViewController<PaymentCh
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath)
-        dismissErrorMessage(animated: true, sender: cell)
         tableView.deselectRow(at: indexPath, animated: true)
         let payment: PaymentInformation
         

--- a/OmiseSDK/PaymentCreatorController.swift
+++ b/OmiseSDK/PaymentCreatorController.swift
@@ -295,7 +295,7 @@ public class PaymentCreatorController : UINavigationController {
         
         if animated {
             UIView.animate(withDuration: TimeInterval(NavigationControllerHideShowBarDuration) + 0.07, delay: 0.0,
-                           options: [.layoutSubviews], animations: animationBlock)
+                           options: [.layoutSubviews, .beginFromCurrentState], animations: animationBlock)
         } else {
             animationBlock()
         }
@@ -321,6 +321,16 @@ public class PaymentCreatorController : UINavigationController {
                 withDuration: TimeInterval(NavigationControllerHideShowBarDuration), delay: 0.0,
                 options: [.layoutSubviews], animations: animationBlock,
                 completion: { _ in
+                    var isCompleted: Bool {
+                        if #available(iOS 13, *) {
+                            return self.topViewController?.additionalSafeAreaInsets.top == 0
+                        } else if #available(iOS 11, *) {
+                            return self.additionalSafeAreaInsets.top == 0
+                        } else {
+                            return true
+                        }
+                    }
+                    guard isCompleted else { return }
                     self.displayingNoticeView.removeFromSuperview()
             })
         } else {
@@ -331,6 +341,8 @@ public class PaymentCreatorController : UINavigationController {
     
     
     public override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        dismissErrorMessage(animated: false, sender: self)
+        
         if let viewController = viewController as? PaymentChooserUI {
             viewController.preferredPrimaryColor = preferredPrimaryColor
             viewController.preferredSecondaryColor = preferredSecondaryColor
@@ -339,6 +351,11 @@ public class PaymentCreatorController : UINavigationController {
             viewController.flowSession = self.paymentSourceCreatorFlowSession
         }
         super.pushViewController(viewController, animated: animated)
+    }
+    
+    public override func popViewController(animated: Bool) -> UIViewController? {
+        dismissErrorMessage(animated: false, sender: self)
+        return super.popViewController(animated: animated)
     }
     
     public override func addChild(_ childController: UIViewController) {


### PR DESCRIPTION
**1. Objective**

The error view in the `PaymentCreatorController` can leave an empty white space after it has been closed. This can happen when the error view is displayed again while the hide animation is still running. Also, it can happen when navigating between view controllers while the error message is shown.

**2. Description of change**

- Dismiss the error view when showing a new view controller or hiding a view controller.
- After finishing the hide animation check if the animation is completed. If not, don't remove the error view.

**3. Quality assurance**

![simRec-high-1](https://user-images.githubusercontent.com/712728/112612194-3786ac00-8e51-11eb-9269-2b847a85ae4f.gif)

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. The priority of change**

Normal