### PR TITLE
[Fix] Card brands breaking capabilities api

### DIFF
--- a/OmiseSDK/CardBrand.swift
+++ b/OmiseSDK/CardBrand.swift
@@ -85,9 +85,9 @@ public enum CardBrand: Int, CustomStringConvertible, Codable {
         case .jcb:
             return "JCB"
         case .amex:
-            return "AMEX"
+            return "American Express"
         case .diners:
-            return "Diners"
+            return "Diners Club"
         case .discover:
             return "Discover"
         case .laser:
@@ -111,9 +111,9 @@ public enum CardBrand: Int, CustomStringConvertible, Codable {
             self = .masterCard
         case "JCB":
             self = .jcb
-        case "AMEX":
+        case "American Express":
             self = .amex
-        case "Diners":
+        case "Diners Club":
             self = .diners
         case "Discover":
             self = .discover


### PR DESCRIPTION
- Fix issue where card brands are now full name for AMEX and Diners card which causes the capabilities to break