### PR TITLE
[CS-1805] Handle deeplink to mobile banking app for authorizing payment flow

### DIFF
--- a/OmiseSDK/AuthorizingPaymentViewController.swift
+++ b/OmiseSDK/AuthorizingPaymentViewController.swift
@@ -210,6 +210,14 @@ extension AuthorizingPaymentViewController: WKNavigationDelegate {
                        type: .default,
                        url.absoluteString)
             }
+        } else if let url = navigationAction.request.url, let scheme = url.scheme?.lowercased(), (scheme != "https" && scheme != "http") {
+            os_log("Redirected to custom-scheme %{private}@ URL",
+                   log: uiLogObject,
+                   type: .debug,
+                   navigationAction.request.url?.absoluteString ?? "<empty>")
+            
+            UIApplication.shared.open(url)
+            decisionHandler(.cancel)
         } else {
             os_log("Redirected to non-expected %{private}@ URL",
                    log: uiLogObject,


### PR DESCRIPTION
- Added the logic to handle custom scheme deeplink on authorize payment flow
- So the app should navigate the user to the selected banking app using deeplink