### PR TITLE
Remove unused variable to enable support for Xcode 15 and Swift 5.9

### DIFF
--- a/OmiseSDK/CreditCardFormViewController.swift
+++ b/OmiseSDK/CreditCardFormViewController.swift
@@ -185,10 +185,6 @@ public class CreditCardFormViewController: UIViewController, PaymentChooserUI, P
     @IBOutlet private var requestingIndicatorView: UIActivityIndicatorView!
     @objc public static let defaultErrorMessageTextColor = UIColor.error
 
-    /// A boolean flag that enables/disables Card.IO integration.
-    @available(*, unavailable, message: "Built in support for Card.ios was removed. You can implement it in your app and call the setCreditCardInformation(number:name:expiration:) method")
-    @objc public var cardIOEnabled = true
-
     /// Factory method for creating CreditCardFormController with given public key.
     /// - parameter publicKey: Omise public key.
     @objc(creditCardFormViewControllerWithPublicKey:)


### PR DESCRIPTION
In Xcode 15 with Swift 5.9, stored properties cannot be marked as unavailable using "@available", rendering the project uncompilable. Furthermore, this property was never used anyway.
