### PR TITLE
Added deeplink info

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Card** and **Creating a Payment Source**.
 #### Creating a Card Token
 
 Normally, merchants must not send credit or debit card data to their own
-servers. So, in order to collect a credit card payment from a
+servers. To collect a credit card payment from a
 customer, merchants will need to first *tokenize* the credit card data using
 Opn Payments API and then use the generated token in place of the card
 data.  You can tokenize credit card data by creating and initializing
@@ -125,7 +125,7 @@ let request = Request<Token>(parameter: tokenParameters)
 
 Opn Payments now supports many payment methods other than credit cards.  You
 may request a payment with one of those supported payment methods from
-a customer by calling `CreateSourceParameter` API. You need to specify
+a customer by calling the `CreateSourceParameter` API. You need to specify
 the parameters (e.g. payment amount and currency) of the source you
 want to create by creating and initializing a `Request<Source>` with
 the `Payment Information` object:
@@ -273,7 +273,7 @@ Opn Payments iOS SDK provides some built-in credit card UI components to make it
 * `CardExpiryDatePicker` - `UIPickerView` implementation that has a month and year column.
 * `CardCVVTextField` - CVV number field.
 
-Additionally fields turn red automatically if their content fails
+Additionally, fields turn red automatically if their content fails
 basic validation (e.g. alphabetic characters in the number field,
 content with wrong length, etc.) and come in 2 supported styles, plain
 and border.
@@ -400,7 +400,7 @@ extension ViewController: OmiseAuthorizingPaymentViewControllerDelegate {
 
 ## Objective-C Compatibility
 
-Opn Payments iOS SDK comes with full Objective-C support. The SDK is designed with the Swift language as a first-class citizen and adopts Swift-only features in the SDK, but also provides an Objective-C counterpart for those features.
+Opn Payments iOS SDK comes with full Objective-C support. The SDK is designed with the Swift language as a first-class citizen, and not only adopts Swift-only features in the SDK, but also provides an Objective-C counterpart for those features.
 If you found an API that is not available in Objective-C, please don't hestitate [to open an issue](https://github.com/omise/omise-ios/issues/new).
 
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 
 ### Authorizing Payment
 
-Some payment methods require the customers to authorize the payment via an authorized URL. This includes the [3-D Secure verification](https://www.omise.co/fraud-protection#3-d-secure), [Internet Banking payment](https://www.omise.co/offsite-payment), [Alipay](https://www.omise.co/alipay). The Opn Payments iOS SDK provides a built-in class to do the authorization.
+Some payment methods require the customers to authorize the payment via an authorized URL. This includes the [3-D Secure verification](https://docs.opn.ooo/fraud-protection#3-d-secure), [Internet Banking payment](https://docs.opn.ooo/offsite-payment), [Alipay](https://docs.opn.ooo/alipay). The Opn Payments iOS SDK provides a built-in class to do the authorization.
 
 On payment methods that require opening the external app (e.g. mobile banking app) to authorize the transaction, set the *return_uri* to a **deeplink** or **applink** to be able to open the merchant app. Else, after the card holder completes authorizing the transaction on the external app, the flow redirects to the normal link in the *return_uri* and opens it on the browser app, and therefore results in the payment not being completed.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://img.shields.io/badge/email-support-yellow.svg?style=flat-square)](mailto:support@omise.co)
 ![CI](https://github.com/omise/omise-ios/workflows/CI/badge.svg?branch=master)
 
-[Opn Payments](https://www.omise.co/) is a payment service provider operating
+[Opn Payments](https://docs.opn.ooo/) is a payment service provider operating
 in Thailand, Japan, and Singapore. Opn Payments provides a set of APIs that
 help merchants of any size accept payments online.
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ extension ViewController: CreditCardFormViewControllerDelegate {
 }
 ```
 
-Alternatively you can also push the view controller onto a `UINavigationController` stack
-like so:
+Alternatively, you can also push the view controller onto a `UINavigationController` stack
+as follows:
 
 ```swift
 @IBAction func displayCreditCardForm() {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Packager%20Manager-compatible-brightgreen?style=flat-square)](https://swift.org/package-manager)
-[![](https://img.shields.io/badge/email-support-yellow.svg?style=flat-square)](mailto:support@omise.co)
+[![](https://img.shields.io/badge/email-support-yellow.svg?style=flat-square)](mailto:support@opn.ooo)
 ![CI](https://github.com/omise/omise-ios/workflows/CI/badge.svg?branch=master)
 
 [Opn Payments](https://docs.opn.ooo/) is a payment service provider operating
@@ -21,7 +21,7 @@ If you run into any issues regarding this SDK and the functionality it
 provides, consult the frequently asked questions in our
 [comprehensive support documents](https://docs.opn.ooo/support).  If
 you can't find an answer there, feel free to
-[email our support team](mailto:support@omise.co).
+[email our support team](mailto:support@opn.ooo).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 [![Omise](https://cdn.omise.co/assets/omise.png)](https://omise.co)
 
-# Omise iOS SDK
+# Opn Payments iOS SDK
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Packager%20Manager-compatible-brightgreen?style=flat-square)](https://swift.org/package-manager)
 [![](https://img.shields.io/badge/email-support-yellow.svg?style=flat-square)](mailto:support@omise.co)
 ![CI](https://github.com/omise/omise-ios/workflows/CI/badge.svg?branch=master)
 
-[Omise](https://www.omise.co/) is a payment service provider operating
-in Thailand, Japan, and Singapore. Omise provides a set of APIs that
+[Opn Payments](https://www.omise.co/) is a payment service provider operating
+in Thailand, Japan, and Singapore. Opn Payments provides a set of APIs that
 help merchants of any size accept payments online.
 
-The Omise iOS SDK provides bindings for
+The Opn Payments iOS SDK provides bindings for
 [tokenizing credit cards](https://www.omise.co/tokens-api) and
 [accepting non-credit-card payments](https://www.omise.co/sources-api)
-using the Omise API allowing developers to safely and easily accept
+using the Opn Payments API allowing developers to safely and easily accept
 payments within apps.
 
 If you run into any issues regarding this SDK and the functionality it
@@ -25,7 +25,7 @@ you can't find an answer there, feel free to
 
 ## Requirements
 
-* Omise API public key. [Register for an Omise account](https://dashboard.omise.co/signup) to obtain your API keys.
+* Opn Payments API public key. [Register for an Opn Payments account](https://dashboard.omise.co/signup) to obtain your API keys.
 * iOS 10 or higher deployment target.
 * Xcode 10.2 or higher (Xcode 12 is recommended)
 * Swift 5.0 or higher (Swift 5.3 is recommended)
@@ -46,7 +46,7 @@ through your server.
 
 ### Carthage
 
-To integrate the OmiseSDK into your Xcode project using [Carthage](https://github.com/Carthage/Carthage), proceed with the following steps:
+To integrate the Opn Payments SDK into your Xcode project using [Carthage](https://github.com/Carthage/Carthage), proceed with the following steps:
 
 1. Add the following line to your `Cartfile`:
 ```
@@ -69,7 +69,7 @@ For more detailed instructions, please read the [official documentation for Cart
 
 ### Swift Package Manager (Xcode 12+)
 
-To integrate the OmiseSDK into your Xcode project using the [Swift Package Manager](https://swift.org/package-manager/), proceed with the following steps:
+To integrate the Opn Payments SDK into your Xcode project using the [Swift Package Manager](https://swift.org/package-manager/), proceed with the following steps:
 
 1. In Xcode, select `File` > `Swift Packages` > `Add Package Dependency...`
 2. Enter the URL for this repository `https://github.com/omise/omise-ios.git`
@@ -82,12 +82,12 @@ If you cloned this project to your local hard drive, you can also
 checkout the `QuickStart.playground`. Otherwise if you'd like all the
 details, read on:
 
-### Omise API
+### Opn Payments API
 
-The Omise iOS SDK provides an easy-to-use library for calling the
-Omise API. The main class for the Omise iOS SDK is `Client` through
-which all requests to the Omise API will be sent. Creating a new
-`Client` object requires an Omise public key.
+The Opn Payments iOS SDK provides an easy-to-use library for calling the
+Opn Payments API. The main class for the Opn Payments iOS SDK is `Client` through
+which all requests to the Opn Payments API will be sent. Creating a new
+`Client` object requires an Opn Payments public key.
 
 ``` swift
 import OmiseSDK
@@ -104,10 +104,10 @@ Card** and **Creating a Payment Source**.
 
 Normally, merchants must not send credit or debit card data to their own
 servers. So, in order to collect a credit card payment from a
-customer, merchants will need to *tokenize* the credit card data using
-Omise API first and then use the generated token in place of the card
+customer, merchants will need to first *tokenize* the credit card data using
+Opn Payments API and then use the generated token in place of the card
 data.  You can tokenize credit card data by creating and initializing
-a `Request<Token>` like so:
+a `Request<Token>` as follows:
 
 ```swift
 let tokenParameters = Token.CreateParameter(
@@ -123,7 +123,7 @@ let request = Request<Token>(parameter: tokenParameters)
 
 #### Creating a Payment Source
 
-Omise now supports many payment methods other than credit cards.  You
+Opn Payments now supports many payment methods other than credit cards.  You
 may request a payment with one of those supported payment methods from
 a customer by calling `CreateSourceParameter` API. You need to specify
 the parameters (e.g. payment amount and currency) of the source you
@@ -182,7 +182,7 @@ func completionHandler(tokenResult: Result<Token, Error>) -> Void {
 
 ### Built-in Forms
 
-Omise iOS SDK provides easy-to-use drop-in UI forms for both Tokenizing a Credit Card and Creating a Payment Source which
+OPn Payments iOS SDK provides easy-to-use drop-in UI forms for both Tokenizing a Credit Card and Creating a Payment Source, which
 you can easily integrate into your app.
 
 #### Credit Card Form
@@ -350,11 +350,14 @@ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 
 ### Authorizing Payment
 
-Some payment methods require the customers to authorize the payment via an authorized URL. This includes the [3-D Secure verification](https://www.omise.co/fraud-protection#3-d-secure), [Internet Banking payment](https://www.omise.co/offsite-payment), [Alipay](https://www.omise.co/alipay). The Omise iOS SDK provides a built-in class to do the authorization.
+Some payment methods require the customers to authorize the payment via an authorized URL. This includes the [3-D Secure verification](https://www.omise.co/fraud-protection#3-d-secure), [Internet Banking payment](https://www.omise.co/offsite-payment), [Alipay](https://www.omise.co/alipay). The Opn Payments iOS SDK provides a built-in class to do the authorization.
+
+On payment methods that require opening the external app (e.g. mobile banking app) to authorize the transaction, set the *return_uri* to a **deeplink** or **applink** to be able to open the merchant app. Else, after the card holder completes authorizing the transaction on the external app, the flow redirects to the normal link in the *return_uri* and opens it on the browser app, and therefore results in the payment not being completed.
+
 
 #### Using built-in Authorizing Payment view controller
 
-You can use the built-in Authorizing Payment view controller by creating an instance of `OmiseAuthorizingPaymentViewController` and set it with `authorized URL` given with the charge and expected `return URL` patterns those were created by merchants.
+You can use the built-in Authorizing Payment view controller by creating an instance of `OmiseAuthorizingPaymentViewController` and set it with `authorized URL` provided with the charge and expected `return URL` patterns created by merchants.
 
 ##### Create an `OmiseAuthorizingPaymentViewController` by code
 
@@ -397,7 +400,7 @@ extension ViewController: OmiseAuthorizingPaymentViewControllerDelegate {
 
 ## Objective-C Compatibility
 
-Omise iOS SDK comes with full Objective-C support. The SDK is designed with the Swift language as a first-class citizen and adopts Swift-only features in the SDK, but it also provides an Objective-C counterpart for those features.
+Opn Payments iOS SDK comes with full Objective-C support. The SDK is designed with the Swift language as a first-class citizen and adopts Swift-only features in the SDK, but also provides an Objective-C counterpart for those features.
 If you found an API that is not available in Objective-C, please don't hestitate [to open an issue](https://github.com/omise/omise-ios/issues/new).
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Omise](https://cdn.omise.co/assets/omise.png)](https://omise.co)
+[![](https://cdn.omise.co/assets/omise.png)](https://omise.co)
 
 # Opn Payments iOS SDK
 
@@ -12,7 +12,7 @@ in Thailand, Japan, and Singapore. Opn Payments provides a set of APIs that
 help merchants of any size accept payments online.
 
 The Opn Payments iOS SDK provides bindings for
-[tokenizing credit cards](https://www.omise.co/tokens-api) and
+[tokenizing credit cards](https://www..co/tokens-api) and
 [accepting non-credit-card payments](https://www.omise.co/sources-api)
 using the Opn Payments API allowing developers to safely and easily accept
 payments within apps.
@@ -265,7 +265,7 @@ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 ##### Custom Credit Card Form
 
 You can create your own credit card form if you want to but please keep in mind that you must not send the credit card information to your server.
-Omise iOS SDK provides some built-in credit card UI components to make it easier to create your own credit card form:
+Opn Payments iOS SDK provides some built-in credit card UI components to make it easier to create your own credit card form:
 
 * `CardNumberTextField` - Provides basic number grouping as the user types.
 * `CardNameTextField` - Cardholder name field.
@@ -410,4 +410,4 @@ Pull requests, issues, and bugfixes are welcome!
 
 ## LICENSE
 
-MIT [See the full license text](https://github.com/omise/omise-ios/blob/master/LICENSE)
+MIT [See the full license text](https://github.com//-ios/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -410,4 +410,4 @@ Pull requests, issues, and bugfixes are welcome!
 
 ## LICENSE
 
-MIT [See the full license text](https://github.com//-ios/blob/master/LICENSE)
+MIT [See the full license text](https://github.com/omise/omise-ios/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in Thailand, Japan, and Singapore. Opn Payments provides a set of APIs that
 help merchants of any size accept payments online.
 
 The Opn Payments iOS SDK provides bindings for
-[tokenizing credit cards](https://www..co/tokens-api) and
+[tokenizing credit cards](https://docs.opn.ooo/tokens-api) and
 [accepting non-credit-card payments](https://www.omise.co/sources-api)
 using the Opn Payments API allowing developers to safely and easily accept
 payments within apps.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ let client = OmiseSDK.Client.init(publicKey: "omise_public_key")
 
 
 The SDK currently
-supports 2 main categories of the requests: **Tokenizing a Credit
+supports 2 main categories of requests: **Tokenizing a Credit
 Card** and **Creating a Payment Source**.
 
 #### Creating a Card Token
@@ -275,7 +275,7 @@ Opn Payments iOS SDK provides some built-in credit card UI components to make it
 
 Additionally, fields turn red automatically if their content fails
 basic validation (e.g. alphabetic characters in the number field,
-content with wrong length, etc.) and come in 2 supported styles, plain
+content with wrong length, etc.) and come in two supported styles, plain
 and border.
 
 #### Built-in Payment Creator Controller
@@ -384,7 +384,7 @@ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 
 ##### Receive `Authorizing Payment` events via the delegate
 
-`OmiseAuthorizingPaymentViewController` send `Authorizing Payment` events to its `delegate` when there's an event occurred.
+`OmiseAuthorizingPaymentViewController` sends `Authorizing Payment` events to its `delegate` when an event occurs.
 
 ```swift
 extension ViewController: OmiseAuthorizingPaymentViewControllerDelegate {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://cdn.omise.co/assets/omise.png)](https://omise.co)
+[![](https://cdn.omise.co/assets/omise.png)](https://opn.ooo)
 
 # Opn Payments iOS SDK
 
@@ -13,13 +13,13 @@ help merchants of any size accept payments online.
 
 The Opn Payments iOS SDK provides bindings for
 [tokenizing credit cards](https://docs.opn.ooo/tokens-api) and
-[accepting non-credit-card payments](https://www.omise.co/sources-api)
+[accepting non-credit-card payments](https://docs.opn.ooo/sources-api)
 using the Opn Payments API allowing developers to safely and easily accept
 payments within apps.
 
 If you run into any issues regarding this SDK and the functionality it
 provides, consult the frequently asked questions in our
-[comprehensive support documents](https://www.omise.co/support).  If
+[comprehensive support documents](https://docs.opn.ooo/support).  If
 you can't find an answer there, feel free to
 [email our support team](mailto:support@omise.co).
 
@@ -34,7 +34,7 @@ you can't find an answer there, feel free to
 
 **Card data should never transit through your server. We recommend that you follow our
 guide on how to safely
-[collect credit information](https://www.omise.co/collecting-card-information).**
+[collect credit information](https://docs.opn.ooo/collecting-card-information).**
 
 To be authorized to create tokens on your own server, you must have a
 currently valid PCI-DSS Attestation of Compliance (AoC) delivered by a
@@ -188,7 +188,7 @@ you can easily integrate into your app.
 #### Credit Card Form
 
 The `CreditCardFormViewController` provides a pre-made credit card form and will automatically
-[tokenize credit card information](https://www.omise.co/security-best-practices) for you.
+[tokenize credit card information](https://docs.opn.ooo/security-best-practices) for you.
 You only need to implement two delegate methods and a way to display the form.
 
 ##### Use Credit Card Form in code
@@ -350,7 +350,7 @@ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 
 ### Authorizing Payment
 
-Some payment methods require the customers to authorize the payment via an authorized URL. This includes the [3-D Secure verification](https://docs.opn.ooo/fraud-protection#3-d-secure), [Internet Banking payment](https://docs.opn.ooo/offsite-payment), [Alipay](https://docs.opn.ooo/alipay). The Opn Payments iOS SDK provides a built-in class to do the authorization.
+Some payment methods require the customers to authorize the payment via an authorized URL. This includes the [3-D Secure verification](https://docs.opn.ooo/fraud-protection#3-d-secure), [Internet Banking payment](https://docs.opn.ooo/internet-banking), [Alipay](https://docs.opn.ooo/alipay). The Opn Payments iOS SDK provides a built-in class to do the authorization.
 
 On payment methods that require opening the external app (e.g. mobile banking app) to authorize the transaction, set the *return_uri* to a **deeplink** or **applink** to be able to open the merchant app. Else, after the card holder completes authorizing the transaction on the external app, the flow redirects to the normal link in the *return_uri* and opens it on the browser app, and therefore results in the payment not being completed.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![](https://cdn.omise.co/assets/omise.png)](https://opn.ooo)
 
 # Opn Payments iOS SDK
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ func completionHandler(tokenResult: Result<Token, Error>) -> Void {
 
 ### Built-in Forms
 
-OPn Payments iOS SDK provides easy-to-use drop-in UI forms for both Tokenizing a Credit Card and Creating a Payment Source, which
+Opn Payments iOS SDK provides easy-to-use drop-in UI forms for both Tokenizing a Credit Card and Creating a Payment Source, which
 you can easily integrate into your app.
 
 #### Credit Card Form


### PR DESCRIPTION
Added a para to state that on payment methods that require opening the external app (e.g. mobile banking app) to authorize the transaction, one must set the return_uri to a deeplink or applink to be able to open the merchant app.