### PR TITLE
Add transID to Netcetera SDK's threeDSRequestorAppURL

### DIFF
--- a/ExampleApp/AppDeeplink.swift
+++ b/ExampleApp/AppDeeplink.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum AppDeeplink: String {
+    case threeDSChallenge = "omise_3ds_challenge"
+
+    var scheme: String {
+        "omiseExampleApp"
+    }
+
+    var url: URL? {
+        URL(string: "\(scheme)://\(rawValue)")
+    }
+}

--- a/ExampleApp/AppDelegate.swift
+++ b/ExampleApp/AppDelegate.swift
@@ -26,9 +26,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         switch components.host {
-        case "omise_3ds_challenge":
+        case AppDeeplink.threeDSChallenge.rawValue:
             print("Omise 3DS Challenge Callback")
-            return true
+            return AuthorizingPayment.shared.appOpen3DSDeeplinkURL(url)
         default:
             print("Unknown deeplink params \(url.host ?? "nil")")
             return false

--- a/ExampleApp/Swift/ProductDetailViewController.swift
+++ b/ExampleApp/Swift/ProductDetailViewController.swift
@@ -124,7 +124,7 @@ class ProductDetailViewController: OMSBaseViewController {
                   let textField = alertController.textFields?.first,
                   let text = textField.text,
                   let url = URL(string: text),
-                  let deeplinkURL = URL(string: "omiseExampleApp://omise_3ds_challenge"),
+                  let deeplinkURL = AppDeeplink.threeDSChallenge.url,
                   let expectedWebReturnURL = URL(string: "https://omise.co/orders")
             else { return }
 

--- a/OmiseSDK.xcodeproj/project.pbxproj
+++ b/OmiseSDK.xcodeproj/project.pbxproj
@@ -101,6 +101,9 @@
 		75AA455F2AB042CC003DE277 /* ThreeDSDeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AA455E2AB042CC003DE277 /* ThreeDSDeviceInfo.swift */; };
 		75B43B572A0277A3004352C7 /* PaymentInformation.Atome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B43B562A0277A3004352C7 /* PaymentInformation.Atome.swift */; };
 		75C5D7B32B0D87860038C0A0 /* AuthorizingPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C5D7B22B0D87860038C0A0 /* AuthorizingPaymentTests.swift */; };
+		75C5D7B72B1040430038C0A0 /* NetceteraThreeDSControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C5D7B62B1040430038C0A0 /* NetceteraThreeDSControllerTests.swift */; };
+		75C5D7BA2B1421100038C0A0 /* AppDeeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C5D7B82B1420CC0038C0A0 /* AppDeeplink.swift */; };
+		75C5D7BB2B1421110038C0A0 /* AppDeeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C5D7B82B1420CC0038C0A0 /* AppDeeplink.swift */; };
 		75D0086C2AFB910A006A85F2 /* AuthorizingPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D0086B2AFB910A006A85F2 /* AuthorizingPayment.swift */; };
 		75DAD88C2A0BA5130098AF96 /* OmiseTestSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 75DAD88B2A0BA5130098AF96 /* OmiseTestSDK */; };
 		75DAD88E2A0BA5130098AF96 /* OmiseTestSDK in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 75DAD88B2A0BA5130098AF96 /* OmiseTestSDK */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -363,6 +366,8 @@
 		75AA455E2AB042CC003DE277 /* ThreeDSDeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSDeviceInfo.swift; sourceTree = "<group>"; };
 		75B43B562A0277A3004352C7 /* PaymentInformation.Atome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentInformation.Atome.swift; sourceTree = "<group>"; };
 		75C5D7B22B0D87860038C0A0 /* AuthorizingPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizingPaymentTests.swift; sourceTree = "<group>"; };
+		75C5D7B62B1040430038C0A0 /* NetceteraThreeDSControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetceteraThreeDSControllerTests.swift; sourceTree = "<group>"; };
+		75C5D7B82B1420CC0038C0A0 /* AppDeeplink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDeeplink.swift; sourceTree = "<group>"; };
 		75D0086B2AFB910A006A85F2 /* AuthorizingPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizingPayment.swift; sourceTree = "<group>"; };
 		75DAD87F2A0B9AE50098AF96 /* OmiseTestSDK */ = {isa = PBXFileReference; lastKnownFileType = text; path = OmiseTestSDK; sourceTree = SOURCE_ROOT; };
 		75DAD88F2A0BB8D80098AF96 /* LocalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalConfig.swift; sourceTree = "<group>"; };
@@ -564,6 +569,7 @@
 				22D480AB1D0EB29C00544CE1 /* Info.plist */,
 				8AF6A1D720E4FEBE00AC5625 /* ExampleApp-Bridging-Header.h */,
 				229E14541D0EBAB5000511DE /* AppDelegate.swift */,
+				75C5D7B82B1420CC0038C0A0 /* AppDeeplink.swift */,
 				8A723A672164D80200D902F5 /* Swift */,
 				8AB3B85F216DCF5C006497B5 /* Shared */,
 				8A723A682164D80C00D902F5 /* Objective-C */,
@@ -740,6 +746,7 @@
 				75AA454C2AAF9034003DE277 /* UILabelCustomizationTests.swift */,
 				75AA454E2AAF903B003DE277 /* ThreeDSTextBoxCustomizationTests.swift */,
 				75C5D7B22B0D87860038C0A0 /* AuthorizingPaymentTests.swift */,
+				75C5D7B62B1040430038C0A0 /* NetceteraThreeDSControllerTests.swift */,
 			);
 			path = 3DSTests;
 			sourceTree = "<group>";
@@ -1436,6 +1443,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A40DA29216B441E00749F45 /* PaymentSettingTableViewController.swift in Sources */,
+				75C5D7BA2B1421100038C0A0 /* AppDeeplink.swift in Sources */,
 				229E14581D0EBAB5000511DE /* AppDelegate.swift in Sources */,
 				8A6AA06E216B9DAE00E49E5E /* OMSBaseViewController.m in Sources */,
 				8A40DA2B216B53E900749F45 /* Tools.swift in Sources */,
@@ -1482,6 +1490,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				75C5D7BB2B1421110038C0A0 /* AppDeeplink.swift in Sources */,
 				8A723A692164D87B00D902F5 /* OMSExampleProductDetailViewController.m in Sources */,
 				8A7A9EBE2166160300F12D86 /* PaymentSettingTableViewController.swift in Sources */,
 				8A6AA06D216B958100E49E5E /* OMSBaseViewController.m in Sources */,
@@ -1510,6 +1519,7 @@
 				2244600A1CF441DC00801D0F /* TokenRequestDelegateDummy.swift in Sources */,
 				753279382A31B40F008048AD /* CountryListViewModelMockup.swift in Sources */,
 				224460051CF43A1500801D0F /* CardNumberTest.swift in Sources */,
+				75C5D7B72B1040430038C0A0 /* NetceteraThreeDSControllerTests.swift in Sources */,
 				7558CC9A2AAF89C1005815DF /* UICustomizationTests.swift in Sources */,
 				987A03211CE5B7D70035417A /* OmiseTokenRequestTest.swift in Sources */,
 				7509D4E72A1C8E3D0050AB38 /* AtomeFormViewModelTests.swift in Sources */,

--- a/OmiseSDK/3DS/AuthorizingPayment.swift
+++ b/OmiseSDK/3DS/AuthorizingPayment.swift
@@ -20,6 +20,10 @@ public class AuthorizingPayment {
 
     public static var shared = AuthorizingPayment()
 
+    public func appOpen3DSDeeplinkURL(_ url: URL) -> Bool {
+        NetceteraThreeDSController.sharedController.appOpen3DSDeeplinkURL(url)
+    }
+
     public func presentAuthPaymentController(
         from topViewController: UIViewController,
         url: URL,

--- a/OmiseSDKTests/3DSTests/AuthorizingPaymentTests.swift
+++ b/OmiseSDKTests/3DSTests/AuthorizingPaymentTests.swift
@@ -3,7 +3,12 @@ import XCTest
 import ThreeDS_SDK
 
 class NetceteraThreeDSControllerMock: NetceteraThreeDSControllerProtocol {
-    var result = NetceteraThreeDSControllerResult.success(())
+
+    func appOpen3DSDeeplinkURL(_ url: URL) -> Bool {
+        return true
+    }
+    
+    var processAuthorizedURLResult = NetceteraThreeDSControllerResult.success(())
     func processAuthorizedURL(
         _ authorizeUrl: URL,
         threeDSRequestorAppURL: String?,
@@ -11,7 +16,7 @@ class NetceteraThreeDSControllerMock: NetceteraThreeDSControllerProtocol {
         in viewController: UIViewController,
         onComplete: @escaping (NetceteraThreeDSControllerResult) -> Void
     ) {
-        onComplete(result)
+        onComplete(processAuthorizedURLResult)
     }
 }
 
@@ -51,7 +56,7 @@ class AuthorizingPaymentTests: XCTestCase {
     func test3DSUserFailedChallenge() {
         let expectation = self.expectation(description: "callback")
 
-        netceteraMockController.result = .failure(NetceteraError.incomplete(event: nil))
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.incomplete(event: nil))
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -67,7 +72,7 @@ class AuthorizingPaymentTests: XCTestCase {
     func test3DSUserCancelledChallenge() {
         let expectation = self.expectation(description: "callback")
 
-        netceteraMockController.result = .failure(NetceteraError.cancelled)
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.cancelled)
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -83,7 +88,7 @@ class AuthorizingPaymentTests: XCTestCase {
     func test3DSUserTimedOutChallenge() {
         let expectation = self.expectation(description: "callback")
         
-        netceteraMockController.result = .failure(NetceteraError.timedout)
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.timedout)
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -99,7 +104,7 @@ class AuthorizingPaymentTests: XCTestCase {
     func test3DSAuthResponseStatusFailed() {
         let expectation = self.expectation(description: "callback")
 
-        netceteraMockController.result = .failure(NetceteraError.authResStatusFailed)
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.authResStatusFailed)
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -115,7 +120,7 @@ class AuthorizingPaymentTests: XCTestCase {
     func test3DSAuthResponseStatusUnknown() {
         let expectation = self.expectation(description: "callback")
 
-        netceteraMockController.result = .failure(NetceteraError.authResStatusUnknown("Some Unknown Status"))
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.authResStatusUnknown("Some Unknown Status"))
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -131,7 +136,7 @@ class AuthorizingPaymentTests: XCTestCase {
     func test3DSSuccess() {
         let expectation = self.expectation(description: "callback")
 
-        netceteraMockController.result = .success(())
+        netceteraMockController.processAuthorizedURLResult = .success(())
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -153,7 +158,7 @@ class AuthorizingPaymentTests: XCTestCase {
             XCTAssertTrue(presentedVC is AuthorizingPaymentWebViewController)
         }
 
-        netceteraMockController.result = .failure(NetceteraError.authResInvalid)
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.authResInvalid)
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -174,7 +179,7 @@ class AuthorizingPaymentTests: XCTestCase {
             XCTAssertTrue(presentedVC is AuthorizingPaymentWebViewController)
         }
 
-        netceteraMockController.result = .failure(NetceteraError.protocolError(event: nil))
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.protocolError(event: nil))
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -195,7 +200,7 @@ class AuthorizingPaymentTests: XCTestCase {
             XCTAssertTrue(presentedVC is AuthorizingPaymentWebViewController)
         }
 
-        netceteraMockController.result = .failure(NetceteraError.runtimeError(event: nil))
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.runtimeError(event: nil))
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -217,7 +222,7 @@ class AuthorizingPaymentTests: XCTestCase {
         }
 
         let challengeError = AnyError("Any error on presenting Netcetera Challenge")
-        netceteraMockController.result = .failure(NetceteraError.presentChallenge(error: challengeError))
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.presentChallenge(error: challengeError))
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -238,7 +243,7 @@ class AuthorizingPaymentTests: XCTestCase {
             XCTAssertTrue(presentedVC is AuthorizingPaymentWebViewController)
         }
 
-        netceteraMockController.result = .failure(NetceteraError.deviceInfoInvalid)
+        netceteraMockController.processAuthorizedURLResult = .failure(NetceteraError.deviceInfoInvalid)
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,
@@ -259,7 +264,7 @@ class AuthorizingPaymentTests: XCTestCase {
             XCTAssertTrue(presentedVC is AuthorizingPaymentWebViewController)
         }
 
-        netceteraMockController.result = .failure(AnyError("Any error during initialization"))
+        netceteraMockController.processAuthorizedURLResult = .failure(AnyError("Any error during initialization"))
         authorizingPayment.presentAuthPaymentController(
             from: topViewController,
             url: authorizeURL,

--- a/OmiseSDKTests/3DSTests/NetceteraThreeDSControllerTests.swift
+++ b/OmiseSDKTests/3DSTests/NetceteraThreeDSControllerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import OmiseSDK
+import ThreeDS_SDK
+
+class NetceteraThreeDSControllerTests: XCTestCase {
+
+    func testThreeDSRequestorAppURLTransaction() {
+        let transactionId = "1234-5678-9012-ABCD"
+        let tests = [
+            "someApp://":
+                "someApp://?transID=\(transactionId)",
+
+            "someApp://3DSChallenge":
+                "someApp://3DSChallenge?transID=\(transactionId)",
+
+            "someApp://3ds/challenge?source=omiseSDK":
+                "someApp://3ds/challenge?source=omiseSDK&transID=\(transactionId)"
+        ]
+
+        let aRes = AuthResponse.ARes(
+            threeDSServerTransID: transactionId,
+            acsTransID: "123",
+            acsSignedContent: nil,
+            acsUIType: nil
+        )
+
+        let netceteraController = NetceteraThreeDSController()
+        for (url, result) in tests {
+            let params = netceteraController.prepareChallengeParameters(
+                aRes: aRes,
+                acsRefNumber: "123",
+                threeDSRequestorAppURL: url
+            )
+            XCTAssertEqual(params.getThreeDSRequestorAppURL(), result)
+        }
+    }
+}

--- a/OmiseSDKTests/3DSTests/NetceteraThreeDSControllerTests.swift
+++ b/OmiseSDKTests/3DSTests/NetceteraThreeDSControllerTests.swift
@@ -17,6 +17,8 @@ class NetceteraThreeDSControllerTests: XCTestCase {
         let netceteraController = NetceteraThreeDSController()
 
         let tests = [
+            "": nil,
+
             "someApp://":
                 "someApp://?transID=\(transactionId)",
 

--- a/OmiseSDKTests/3DSTests/NetceteraThreeDSControllerTests.swift
+++ b/OmiseSDKTests/3DSTests/NetceteraThreeDSControllerTests.swift
@@ -6,6 +6,16 @@ class NetceteraThreeDSControllerTests: XCTestCase {
 
     func testThreeDSRequestorAppURLTransaction() {
         let transactionId = "1234-5678-9012-ABCD"
+
+        let aRes = AuthResponse.ARes(
+            threeDSServerTransID: transactionId,
+            acsTransID: "123",
+            acsSignedContent: nil,
+            acsUIType: nil
+        )
+
+        let netceteraController = NetceteraThreeDSController()
+
         let tests = [
             "someApp://":
                 "someApp://?transID=\(transactionId)",
@@ -17,14 +27,6 @@ class NetceteraThreeDSControllerTests: XCTestCase {
                 "someApp://3ds/challenge?source=omiseSDK&transID=\(transactionId)"
         ]
 
-        let aRes = AuthResponse.ARes(
-            threeDSServerTransID: transactionId,
-            acsTransID: "123",
-            acsSignedContent: nil,
-            acsUIType: nil
-        )
-
-        let netceteraController = NetceteraThreeDSController()
         for (url, result) in tests {
             let params = netceteraController.prepareChallengeParameters(
                 aRes: aRes,


### PR DESCRIPTION
NetceteraThreeDSController appends current transactionID to the `threeDSRequestorAppURL` (deeplink URL) parameter passed from merchant

<img width="649" alt="Screenshot 2023-11-27 at 15 13 04" src="https://github.com/omise/omise-ios/assets/17623015/7e4cd879-ca28-44cc-87a8-3b2ad8e8a212">
