### PR TITLE
Replaced NetceteraSDK's License with API Key

### DIFF
--- a/ExampleApp/Shared/LocalConfig.swift
+++ b/ExampleApp/Shared/LocalConfig.swift
@@ -12,7 +12,8 @@ import OmiseSDK
 struct LocalConfig: Codable {
     var publicKey: String = "pkey_"
     var devMode = false
-
+    var netceteraAPIKey: String = ""
+    
     private let devVaultBaseURL: String?
     private let devApiBaseURL: String?
 

--- a/ExampleApp/Swift/ProductDetailViewController.swift
+++ b/ExampleApp/Swift/ProductDetailViewController.swift
@@ -25,6 +25,8 @@ class ProductDetailViewController: OMSBaseViewController {
                 print("Capability Country: \(capability.countryCode)")
             }
         }
+
+        AuthorizingPayment.shared.setAPIKey(LocalConfig.default.netceteraAPIKey)
     }
     
     override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {

--- a/OmiseSDK.xcodeproj/project.pbxproj
+++ b/OmiseSDK.xcodeproj/project.pbxproj
@@ -2355,7 +2355,7 @@
 			repositoryURL = "https://github.com/ios-3ds-sdk/SPM.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.3.74;
+				version = 2.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OmiseSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OmiseSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ios-3ds-sdk/SPM.git",
         "state": {
           "branch": null,
-          "revision": "1ba85e40625efcbcf81c524b326d4e4a59a90a64",
-          "version": "2.3.74"
+          "revision": "a4e55d7f10294ea81abd1db393ae05606a5efa46",
+          "version": "2.4.0"
         }
       }
     ]

--- a/OmiseSDK/3DS/AuthorizingPayment.swift
+++ b/OmiseSDK/3DS/AuthorizingPayment.swift
@@ -20,6 +20,11 @@ public class AuthorizingPayment {
 
     public static var shared = AuthorizingPayment()
 
+    // Temporary POC Solution
+    public func setAPIKey(_ apiKey: String) {
+        NetceteraThreeDSController.sharedController.setAPIKey(apiKey)
+    }
+
     public func appOpen3DSDeeplinkURL(_ url: URL) -> Bool {
         NetceteraThreeDSController.sharedController.appOpen3DSDeeplinkURL(url)
     }

--- a/OmiseSDK/3DS/NetceteraThreeDSController.swift
+++ b/OmiseSDK/3DS/NetceteraThreeDSController.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 Omise. All rights reserved.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import ThreeDS_SDK
 
@@ -44,6 +46,7 @@ struct AuthResponse: Codable {
 
 protocol NetceteraThreeDSControllerProtocol: AnyObject {
     typealias NetceteraThreeDSControllerResult = Result<Void, Error>
+    func setAPIKey(_ apiKey: String) // Temporary POC Solution
     func appOpen3DSDeeplinkURL(_ url: URL) -> Bool
     func processAuthorizedURL(
         _ authorizeUrl: URL,
@@ -94,6 +97,7 @@ class NetceteraThreeDSController {
         }
     }
 
+    private var apiKey: String = ""
     static var sharedController: NetceteraThreeDSControllerProtocol = NetceteraThreeDSController()
     private static var uiCustomization: ThreeDSUICustomization?
 
@@ -117,7 +121,7 @@ class NetceteraThreeDSController {
         let configBuilder = ConfigurationBuilder()
         do {
             try configBuilder.add(self.newScheme())
-            try configBuilder.license(key: TestData.licenceKey.value)
+            try configBuilder.api(key: apiKey)
             try configBuilder.log(to: .info)
             let configParameters = configBuilder.configParameters()
 
@@ -159,6 +163,10 @@ class NetceteraThreeDSController {
 }
 
 extension NetceteraThreeDSController: NetceteraThreeDSControllerProtocol {
+    public func setAPIKey(_ key: String) {
+        self.apiKey = key
+    }
+
     public func appOpen3DSDeeplinkURL(_ url: URL) -> Bool {
         ThreeDSSDKAppDelegate.shared.appOpened(url: url)
     }

--- a/OmiseSDKTests/3DSTests/AuthorizingPaymentTests.swift
+++ b/OmiseSDKTests/3DSTests/AuthorizingPaymentTests.swift
@@ -3,6 +3,8 @@ import XCTest
 import ThreeDS_SDK
 
 class NetceteraThreeDSControllerMock: NetceteraThreeDSControllerProtocol {
+    func setAPIKey(_ apiKey: String) {
+    }
 
     func appOpen3DSDeeplinkURL(_ url: URL) -> Bool {
         return true


### PR DESCRIPTION
- Changed NetceteraSDK version to 2.4.0
- Replaced NetceteraSDK's License with API Key
- Added temporary parameter `netceteraAPIKey` to LocalConfig