### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @omise/maintainers


### PR DESCRIPTION
Removing Codeowners  as it is now in the .github central repository that is applicable to all other repositories