### PR TITLE
Use capabilities in Code mode fixed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Run xcodebuild with tests
-      run: xcodebuild -project OmiseSDK.xcodeproj/ -scheme OmiseSDK -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 11,OS=16.2' -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+      run: xcodebuild -project dev.xcodeproj/ -scheme OmiseSDK -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 11,OS=16.2' -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
     - name: Convert Xcode coverage to SonarCloud format
       run: bash xccov-to-sonarqube-generic.sh build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml

--- a/ExampleApp/Views/ProductDetailViewController.swift
+++ b/ExampleApp/Views/ProductDetailViewController.swift
@@ -99,6 +99,11 @@ class ProductDetailViewController: BaseViewController {
             allowedPaymentMethods: allowedPaymentMethods,
             paymentDelegate: self
         )
+
+        if usesCapabilityDataForPaymentMethods, let capability = self.capability {
+            paymentCreatorController.applyPaymentMethods(from: capability)
+        }
+
         present(paymentCreatorController, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Code mode in Example app forced to use Capabilites from settings only. 
This fix allows to use payment methods from Capabilities API or Settings.