### PR TITLE
Prevent SDK from failing during Capabilities parsing (v5.0.0)

### DIFF
--- a/OmiseSDK/Capability.swift
+++ b/OmiseSDK/Capability.swift
@@ -246,8 +246,11 @@ extension Capability.Backend {
         case .unknown(let sourceType):
             self.payment = .unknownSource(sourceType, configurations: [:])
         case .card:
-            let supportedBrand = try container.decode(Set<CardBrand>.self, forKey: .cardBrands)
-            self.payment = .card(supportedBrand)
+            let supportedBrand = try container.decode(Set<String>.self, forKey: .cardBrands)
+            let cardBrands = supportedBrand.compactMap {
+                CardBrand(rawValue: $0)
+            }
+            self.payment = .card(Set(cardBrands))
         case .source(let value) where value.isInstallmentSource:
             let allowedInstallmentTerms = IndexSet(try container.decode(Array<Int>.self, forKey: .allowedInstallmentTerms))
             // swiftlint:disable:next force_unwrapping

--- a/OmiseSDK/CardBrand.swift
+++ b/OmiseSDK/CardBrand.swift
@@ -1,25 +1,25 @@
 import Foundation
 
 /// Brand of the Card Network
-public enum CardBrand: Int, CustomStringConvertible, Codable {
+public enum CardBrand: String, CustomStringConvertible, Codable {
     
     /// VISA card newtwork brand
-    case visa
+    case visa = "Visa"
     /// Master Card card newtwork brand
-    case masterCard
+    case masterCard = "MasterCard"
     /// jcb card newtwork brand
-    case jcb
+    case jcb = "JCB"
     /// AMEX card newtwork brand
-    case amex
+    case amex = "American Express"
     /// Diners card newtwork brand
-    case diners
+    case diners = "Diners Club"
     /// Laser card newtwork brand
-    case laser
+    case laser = "Laser"
     /// Maestro card newtwork brand
-    case maestro
+    case maestro = "Maestro"
     /// Discover card newtwork brand
-    case discover
-    
+    case discover = "Discover"
+
     public static let all: [CardBrand] = [
         visa,
         masterCard,
@@ -76,52 +76,6 @@ public enum CardBrand: Int, CustomStringConvertible, Codable {
     }
     
     public var description: String {
-        switch self {
-        case .visa:
-            return "Visa"
-        case .masterCard:
-            return "MasterCard"
-        case .jcb:
-            return "JCB"
-        case .amex:
-            return "American Express"
-        case .diners:
-            return "Diners Club"
-        case .discover:
-            return "Discover"
-        case .laser:
-            return "Laser"
-        case .maestro:
-            return "Maestro"
-        }
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(description)
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        switch try container.decode(String.self) {
-        case "Visa":
-            self = .visa
-        case "MasterCard":
-            self = .masterCard
-        case "JCB":
-            self = .jcb
-        case "American Express":
-            self = .amex
-        case "Diners Club":
-            self = .diners
-        case "Discover":
-            self = .discover
-        case "Laser":
-            self = .laser
-        case "Maestro":
-            self = .maestro
-        default:
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid Card Brand value")
-        }
+        self.rawValue
     }
 }

--- a/OmiseSDKTests/Fixtures/objects/capability.json
+++ b/OmiseSDKTests/Fixtures/objects/capability.json
@@ -56,7 +56,8 @@
       "card_brands": [
         "JCB",
         "Visa",
-        "MasterCard"
+        "MasterCard",
+        "UnionPay"
       ],
       "installment_terms": null
     },


### PR DESCRIPTION
Capabilities parsing was failing if unsupported Card Brand appears in the list (e.g. UnionPay)

- UnionPay was added to capabilities.json mock file 
- Card Brand and Capabilities were refactored to make current unit tests pass

<img width="936" alt="Screenshot 2024-01-15 at 09 32 21" src="https://github.com/omise/omise-ios/assets/17623015/16dba4f6-5e1d-45e0-ae22-c938652f0cb9">


