### PR TITLE
Prevent SDK from failing during Capabilities parsing (v4.27.0)

### DIFF
--- a/OmiseSDK/Capability.swift
+++ b/OmiseSDK/Capability.swift
@@ -238,8 +238,11 @@ extension Capability.Backend {
 
         switch type {
         case .card:
-            let supportedBrand = try container.decode(Set<CardBrand>.self, forKey: .cardBrands)
-            self.payment = .card(supportedBrand)
+            let supportedBrand = try container.decode(Set<String>.self, forKey: .cardBrands)
+            let cardBrands = supportedBrand.compactMap {
+                CardBrand.from(string: $0)
+            }
+            self.payment = .card(Set(cardBrands))
         case .source(let value) where value.isInstallmentSource:
             let allowedInstallmentTerms = IndexSet(try container.decode(Array<Int>.self, forKey: .allowedInstallmentTerms))
             // swiftlint:disable:next force_unwrapping

--- a/OmiseSDK/CardBrand.swift
+++ b/OmiseSDK/CardBrand.swift
@@ -105,25 +105,36 @@ public enum CardBrand: Int, CustomStringConvertible, Codable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        switch try container.decode(String.self) {
-        case "Visa":
-            self = .visa
-        case "MasterCard":
-            self = .masterCard
-        case "JCB":
-            self = .jcb
-        case "American Express":
-            self = .amex
-        case "Diners Club":
-            self = .diners
-        case "Discover":
-            self = .discover
-        case "Laser":
-            self = .laser
-        case "Maestro":
-            self = .maestro
-        default:
+        let stringValue = try container.decode(String.self)
+        if let cardBrand = CardBrand.from(string: stringValue) {
+            self = cardBrand
+        } else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid Card Brand value")
+        }
+    }
+}
+
+extension CardBrand {
+    static func from(string: String) -> CardBrand? {
+        switch string {
+        case "Visa":
+            return .visa
+        case "MasterCard":
+            return .masterCard
+        case "JCB":
+            return .jcb
+        case "American Express":
+            return .amex
+        case "Diners Club":
+            return .diners
+        case "Discover":
+            return .discover
+        case "Laser":
+            return .laser
+        case "Maestro":
+            return .maestro
+        default:
+            return nil
         }
     }
 }

--- a/OmiseSDKTests/Fixtures/objects/capability.json
+++ b/OmiseSDKTests/Fixtures/objects/capability.json
@@ -56,7 +56,8 @@
       "card_brands": [
         "JCB",
         "Visa",
-        "MasterCard"
+        "MasterCard",
+        "UnionPay"
       ],
       "installment_terms": null
     },

--- a/dev.xcodeproj
+++ b/dev.xcodeproj
@@ -1,0 +1,1 @@
+OmiseSDK.xcodeproj


### PR DESCRIPTION
Capabilities parsing was failing if unsupported Card Brand appears in the list (e.g. UnionPay).

- UnionPay was added to capabilities.json mock file 
- Card Brand and Capabilities were refactored to make current unit tests pass