### PR TITLE
Add rules to sort list of Payment Methods coming from Capabilities (v5.0.0)

### DIFF
--- a/OmiseSDK/Helpers/Extensions/Array+Helpers.swift
+++ b/OmiseSDK/Helpers/Extensions/Array+Helpers.swift
@@ -6,3 +6,19 @@ extension Array {
         return self[index]
     }
 }
+
+extension Array where Element: Equatable {
+    func reorder(by preferredOrder: [Element]) -> [Element] {
+        return self.sorted { (a, b) -> Bool in
+            guard let first = preferredOrder.firstIndex(of: a) else {
+                return false
+            }
+
+            guard let second = preferredOrder.firstIndex(of: b) else {
+                return true
+            }
+
+            return first < second
+        }
+    }
+}

--- a/OmiseSDK/Helpers/Extensions/Array+Helpers.swift
+++ b/OmiseSDK/Helpers/Extensions/Array+Helpers.swift
@@ -9,7 +9,7 @@ extension Array {
 
 extension Array where Element: Equatable {
     func reorder(by preferredOrder: [Element]) -> [Element] {
-        return self.sorted { (a, b) -> Bool in
+        self.sorted { (a, b) -> Bool in
             guard let first = preferredOrder.firstIndex(of: a) else {
                 return false
             }

--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -41,7 +41,7 @@ enum PaymentChooserOption: CaseIterable, Equatable, CustomStringConvertible {
 
     static var alphabetical: [PaymentChooserOption] {
         return PaymentChooserOption.allCases.sorted {
-            $0.description.localizedCompare($1.description) == .orderedAscending
+            $0.description.localizedCaseInsensitiveCompare($1.description) == .orderedAscending
         }
     }
 

--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -40,7 +40,7 @@ enum PaymentChooserOption: CaseIterable, Equatable, CustomStringConvertible {
     case truemoneyJumpApp
 
     static var alphabetical: [PaymentChooserOption] {
-        return PaymentChooserOption.allCases.sorted {
+        PaymentChooserOption.allCases.sorted {
             $0.description.localizedCaseInsensitiveCompare($1.description) == .orderedAscending
         }
     }

--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -41,7 +41,7 @@ enum PaymentChooserOption: CaseIterable, Equatable, CustomStringConvertible {
 
     static var alphabetical: [PaymentChooserOption] {
         return PaymentChooserOption.allCases.sorted {
-            $0.description < $1.description
+            $0.description.localizedCompare($1.description) == .orderedAscending
         }
     }
 

--- a/OmiseSDK/PaymentChooserViewController.swift
+++ b/OmiseSDK/PaymentChooserViewController.swift
@@ -3,41 +3,74 @@ import UIKit
 import os
 
 enum PaymentChooserOption: CaseIterable, Equatable, CustomStringConvertible {
-    case creditCard
-    case installment
-    case internetBanking
-    case mobileBanking
-    case tescoLotus
-    case conbini
-    case payEasy
-    case netBanking
     case alipay
     case alipayCN
     case alipayHK
     case atome
-    case dana
-    case gcash
-    case kakaoPay
-    case touchNGoAlipayPlus
-    case promptpay
-    case paynow
-    case truemoney
-    case truemoneyJumpApp
-    case citiPoints
-    case fpx
-    case rabbitLinepay
-    case ocbcPao
-    case ocbcDigital
-    case grabPay
     case boost
+    case citiPoints
+    case conbini
+    case creditCard
+    case dana
+    case duitNowOBW
+    case duitNowQR
+    case fpx
+    case gcash
+    case grabPay
+    case grabPayRms
+    case installment
+    case internetBanking
+    case kakaoPay
+    case maybankQRPay
+    case mobileBanking
+    case netBanking
+    case ocbcDigital
+    case ocbcPao
+    case payEasy
+    case paynow
+    case payPay
+    case promptpay
+    case rabbitLinepay
     case shopeePay
     case shopeePayJumpApp
-    case maybankQRPay
-    case duitNowQR
-    case duitNowOBW
+    case tescoLotus
     case touchNGo
-    case grabPayRms
-    case payPay
+    case touchNGoAlipayPlus
+    case truemoney
+    case truemoneyJumpApp
+
+    static var alphabetical: [PaymentChooserOption] {
+        return PaymentChooserOption.allCases.sorted {
+            $0.description < $1.description
+        }
+    }
+
+    static let topList: [PaymentChooserOption] = [
+        .creditCard,
+        .paynow,
+        .promptpay,
+        .truemoney,
+        .truemoneyJumpApp,
+        .mobileBanking,
+        .internetBanking,
+        .alipay,
+        .installment,
+        .ocbcDigital,
+        .ocbcPao,
+        .rabbitLinepay,
+        .shopeePay,
+        .shopeePayJumpApp,
+        .alipayCN,
+        .alipayHK
+    ]
+
+    static var sorting: [PaymentChooserOption] {
+        var sorted = topList
+        for item in alphabetical where !sorted.contains(item) {
+            sorted.append(item)
+        }
+        return sorted
+    }
 
     var description: String {
         switch self {
@@ -577,7 +610,7 @@ class PaymentChooserViewController: AdaptableStaticTableViewController<PaymentCh
         var paymentMethodsToShow = paymentOptions(from: allowedPaymentMethods)
         paymentMethodsToShow = appendCreditCardPayment(paymentOptions: paymentMethodsToShow)
         paymentMethodsToShow = filterTrueMoney(paymentOptions: paymentMethodsToShow)
-        showingValues = paymentMethodsToShow
+        showingValues = paymentMethodsToShow.reorder(by: PaymentChooserOption.sorting)
 
         os_log("Payment Chooser: Showing options - %{private}@",
                log: uiLogObject,

--- a/OmiseSDKTests/Views/PaymentChooserViewControllerTests.swift
+++ b/OmiseSDKTests/Views/PaymentChooserViewControllerTests.swift
@@ -87,4 +87,94 @@ class PaymentChooserViewControllerTests: XCTestCase {
         XCTAssertFalse(vc.showingValues.contains(.truemoneyJumpApp))
         XCTAssertFalse(vc.showingValues.contains(.truemoney))
     }
+
+    func testAlphabetSorting() {
+        let vc = PaymentChooserViewController()
+        vc.loadView()
+
+        let sorted: [PaymentChooserOption] = [
+            .alipay,
+            .alipayCN,
+            .alipayHK,
+            .atome,
+            .boost,
+            .citiPoints,
+            .conbini,
+            .creditCard,
+            .dana,
+            .duitNowOBW,
+            .duitNowQR,
+            .fpx,
+            .gcash,
+            .grabPay,
+            .grabPayRms,
+            .installment,
+            .internetBanking,
+            .kakaoPay,
+            .maybankQRPay,
+            .mobileBanking,
+            .netBanking,
+            .ocbcDigital,
+            .ocbcPao,
+            .payEasy,
+            .paynow,
+            .payPay,
+            .promptpay,
+            .rabbitLinepay,
+            .shopeePay,
+            .shopeePayJumpApp,
+            .tescoLotus,
+            .touchNGoAlipayPlus,  // TNG eWallet
+            .touchNGo,
+            .truemoneyJumpApp, // TrueMoney
+            .truemoney // TrueMoney Wallet
+        ]
+
+        XCTAssertEqual(PaymentChooserOption.alphabetical, sorted)
+    }
+
+    func testFilteringAndSorting() {
+        let filteredAndSorted: [PaymentChooserOption] = [
+            .creditCard,
+            .paynow,
+            .promptpay,
+            .truemoneyJumpApp, // TrueMoney
+            .mobileBanking,
+            .internetBanking,
+            .alipay,
+            .installment,
+            .ocbcDigital,
+            .ocbcPao,
+            .rabbitLinepay,
+            .shopeePay,
+            .shopeePayJumpApp,
+            .alipayCN,
+            .alipayHK,
+            .atome,
+            .boost,
+            .citiPoints,
+            .conbini,
+            .dana,
+            .duitNowOBW,
+            .duitNowQR,
+            .fpx,
+            .gcash,
+            .grabPay,
+            .grabPayRms,
+            .kakaoPay,
+            .maybankQRPay,
+            .netBanking,
+            .payEasy,
+            .payPay,
+            .tescoLotus,
+            .touchNGoAlipayPlus, // TNG eWallet
+            .touchNGo
+        ]
+
+        let vc = PaymentChooserViewController()
+        vc.loadView()
+
+        vc.allowedPaymentMethods = allSourceTypes
+        XCTAssertEqual(vc.showingValues, filteredAndSorted)
+    }
 }


### PR DESCRIPTION
- Add sorting rules for PaymentChooserOption
- Sort Payment Methods list

![MIT-2097-1](https://github.com/omise/omise-ios/assets/17623015/04195b23-53ad-4863-828b-9a33e4d25133)
![MIT-2097-2](https://github.com/omise/omise-ios/assets/17623015/ad41d4db-490c-4e97-a88e-4d61aa870217)
![MIT-2097-3](https://github.com/omise/omise-ios/assets/17623015/84f377bb-ac4b-430a-9cc2-cd1018066176)
