### PR TITLE
Example App: fix return url to properly close webview on auth success (v5.0.0)

### DIFF
--- a/ExampleApp/Views/ProductDetailViewController.swift
+++ b/ExampleApp/Views/ProductDetailViewController.swift
@@ -126,8 +126,8 @@ class ProductDetailViewController: BaseViewController {
             guard let textField = alertController.textFields?.first,
                   let text = textField.text,
                   let url = URL(string: text),
-                  let expectedReturnURL = URLComponents(string: "http://www.example.com/orders") else { return }
-            
+                  let expectedReturnURL = URLComponents(string: "https://opn.ooo/") else { return }
+
             let handlerController =
                 AuthorizingPaymentViewController
                     .makeAuthorizingPaymentViewControllerNavigationWithAuthorizedURL(


### PR DESCRIPTION
Authorization url for payment with credit card completes with redirection to "https://opn.ooo/". This value is used by example app to hide webview on authorization success.