### PR TITLE
By default payment method provided are verified by its presence in capability API

### DIFF
--- a/ExampleApp/Views/ProductDetailViewController.swift
+++ b/ExampleApp/Views/ProductDetailViewController.swift
@@ -31,7 +31,6 @@ class ProductDetailViewController: BaseViewController {
             amount: paymentAmount,
             currency: paymentCurrencyCode,
             allowedPaymentMethods: usesCapabilityDataForPaymentMethods ? nil : allowedPaymentMethods,
-            skipCapabilityValidation: true,
             isCardPaymentAllowed: true,
             handleErrors: true,
             delegate: self

--- a/OmiseSDK/Sources/OmiseSDK.swift
+++ b/OmiseSDK/Sources/OmiseSDK.swift
@@ -62,7 +62,7 @@ public class OmiseSDK {
         amount: Int64,
         currency: String,
         allowedPaymentMethods: [SourceType]? = nil,
-        skipCapabilityValidation: Bool = true,
+        skipCapabilityValidation: Bool = false,
         isCardPaymentAllowed: Bool = true,
         handleErrors: Bool = true,
         delegate: ChoosePaymentMethodDelegate


### PR DESCRIPTION
When merchant pass explicit payment methods to OmiseSDK, the only payment methods available in Capability will be presented on the screen.