### PR TITLE
Fix SonarCloud "Cognitive Complexity" warning in NetceteraThreeDSController

### DIFF
--- a/OmiseSDK/Sources/3DS/NetceteraThreeDSController.swift
+++ b/OmiseSDK/Sources/3DS/NetceteraThreeDSController.swift
@@ -187,18 +187,8 @@ extension NetceteraThreeDSController: NetceteraThreeDSControllerProtocol {
                                 return
                             }
 
-                            switch response.status {
-                            case .success:
-                                onComplete(.success(()))
+                            guard !Self.processAuthenticationResponse(response, onComplete: onComplete) else {
                                 return
-                            case .failed:
-                                onComplete(.failure(NetceteraThreeDSController.Errors.authResStatusFailed))
-                                return
-                            case .unknown:
-                                onComplete(.failure(NetceteraThreeDSController.Errors.authResStatusUnknown(response.serverStatus)))
-                                return
-                            case .challenge:
-                                break
                             }
 
                             DispatchQueue.main.async {
@@ -219,6 +209,22 @@ extension NetceteraThreeDSController: NetceteraThreeDSControllerProtocol {
                     onComplete(.failure(error))
                 }
             }
+        }
+    }
+
+    static func processAuthenticationResponse(_ response: AuthResponse, onComplete: ((Result<Void, Error>) -> Void)) -> Bool {
+        switch response.status {
+        case .success:
+            onComplete(.success(()))
+            return true
+        case .failed:
+            onComplete(.failure(NetceteraThreeDSController.Errors.authResStatusFailed))
+            return true
+        case .unknown:
+            onComplete(.failure(NetceteraThreeDSController.Errors.authResStatusUnknown(response.serverStatus)))
+            return true
+        case .challenge:
+            return false
         }
     }
 

--- a/OmiseSDK/Sources/3DS/NetceteraThreeDSController.swift
+++ b/OmiseSDK/Sources/3DS/NetceteraThreeDSController.swift
@@ -149,7 +149,6 @@ extension NetceteraThreeDSController: NetceteraThreeDSControllerProtocol {
         ThreeDSSDKAppDelegate.shared.appOpened(url: url)
     }
 
-    // swiftlint:disable:next function_body_length
     func processAuthorizedURL(
         _ authorizeUrl: URL,
         threeDSRequestorAppURL: String?,


### PR DESCRIPTION
Refactor paste() function of NetceteraThreeDSController to fix SoundCloud warning "Refactor this function to reduce its Cognitive Complexity from 21 to the 15 allowed"