### PR TITLE
[CS-3055] fixed invalid api baseUrl

### DIFF
--- a/ExampleApp.xcodeproj/project.pbxproj
+++ b/ExampleApp.xcodeproj/project.pbxproj
@@ -457,7 +457,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/omise/omise-ios.git";
 			requirement = {
-				branch = "feature/MIT-2470";
+				branch = master;
 				kind = branch;
 			};
 		};

--- a/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "f131717f980b1b6f5251428da012f188d1eaff4e6fa62f7a3121859345471b87",
   "pins" : [
     {
       "identity" : "omise-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omise/omise-ios.git",
       "state" : {
-        "branch" : "feature/MIT-2470",
-        "revision" : "4f1bbf9a0f0828c7531664276fc244fd8433a869"
+        "branch" : "master",
+        "revision" : "c54d16bd6d8f037c0bcc8da3ce0d140563134944"
       }
     },
     {
@@ -19,5 +20,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/OmiseSDK/Sources/OmiseAPI/OmiseAPI.swift
+++ b/OmiseSDK/Sources/OmiseAPI/OmiseAPI.swift
@@ -8,7 +8,7 @@ enum OmiseServerType {
 
 extension OmiseServerType {
     // swiftlint:disable force_unwrapping
-    private var apiServerURL: String { "https://vault.omise.co" }
+    private var apiServerURL: String { "https://api.omise.co" }
     private var vaultServerURL: String { "https://vault.omise.co" }
     
     var url: URL {

--- a/OmiseSDK/Sources/OmiseAPI/Payloads/CreateSourcePayload.swift
+++ b/OmiseSDK/Sources/OmiseAPI/Payloads/CreateSourcePayload.swift
@@ -12,7 +12,7 @@ public struct CreateSourcePayload: Equatable {
     /// Current SDK platform type
     let platform = "IOS"
 
-    init(amount: Int64, currency: String, details: Source.Payment) {
+    public init(amount: Int64, currency: String, details: Source.Payment) {
         self.amount = amount
         self.currency = currency
         self.details = details

--- a/OmiseSDK/Sources/OmiseSDK.swift
+++ b/OmiseSDK/Sources/OmiseSDK.swift
@@ -6,7 +6,7 @@ public class OmiseSDK {
     public static var shared = OmiseSDK(publicKey: "pkey_")
 
     /// OmiseSDK version
-    public let version: String = "5.2.0"
+    public let version: String = "5.2.1"
 
     /// Public Key associated with this instance of OmiseSDK
     public let publicKey: String


### PR DESCRIPTION
## Description
Fixed invalid api baseUrl and make access modifier of create payment source to public

Related issue: [#302](https://github.com/omise/omise-ios/issues/302)