### PR TITLE
Fix: set installment init to public

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run linting
       uses: norio-nomura/action-swiftlint@3.2.1
       with:
@@ -21,10 +21,18 @@ jobs:
     env:
         BUILD_WRAPPER_OUT_DIR: buildwrapper # Directory where build-wrapper output will be placed
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
+    - name: Setup Xcode 16.1
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.1.0'
+        
+    - name: List available simulators
+      run: xcrun simctl list devices
+      
     - name: Run xcodebuild with tests
-      run: xcodebuild -project dev.xcodeproj/ -scheme OmiseSDK -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.5' -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+      run: xcodebuild -project dev.xcodeproj/ -scheme OmiseSDK -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 16' -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
     - name: Convert Xcode coverage to SonarCloud format
       run: bash xccov-to-sonarqube-generic.sh build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
@@ -33,7 +41,7 @@ jobs:
       run: xattr -w com.apple.xcode.CreatedByBuildSystem true ./build
           
     - name: Upload coverage report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: sonarqube-generic-coverage.xml
         retention-days: 5 # Artifact will be available only for 5 days.
@@ -51,13 +59,13 @@ jobs:
     needs: test
     steps:
       - name: Checkout repository on branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.HEAD_REF }}
           fetch-depth: 0
           
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Run sonar-scanner
         uses: SonarSource/sonarcloud-github-action@master

--- a/OmiseSDK/Sources/OmiseAPI/JSON Models/Source/Source.Payment.Installment.swift
+++ b/OmiseSDK/Sources/OmiseAPI/JSON Models/Source/Source.Payment.Installment.swift
@@ -11,6 +11,16 @@ extension Source.Payment {
         // swiftlint:disable:previous discouraged_optional_boolean
         /// Source type of payment
         var sourceType: SourceType
+        
+        public init(
+            installmentTerm: Int,
+            zeroInterestInstallments: Bool?,// swiftlint:disable:this discouraged_optional_boolean
+            sourceType: SourceType
+        ) {
+            self.installmentTerm = installmentTerm
+            self.zeroInterestInstallments = zeroInterestInstallments
+            self.sourceType = sourceType
+        }
     }
 }
 

--- a/OmiseSDKTests/3DS/SHA512Tests.swift
+++ b/OmiseSDKTests/3DS/SHA512Tests.swift
@@ -7,7 +7,6 @@ class SHA512Tests: XCTestCase {
     func testSHA512EmptyString() {
         let emptyString = ""
         let expectedHash = Data(
-            // swiftlint:disable:next multiline_literal_brackets
             [ // expected SHA-512 hash of empty string
                 0xcf, 0x83, 0xe1, 0x35, 0x7e, 0xef, 0xb8, 0xbd,
                 0xf1, 0x54, 0x28, 0x50, 0xd6, 0x6d, 0x80, 0x07,


### PR DESCRIPTION
## Description

- make installment object initializer to public so that merchant could create their own installment for source creation.