### PR TITLE
add weak self & remove observers to prevent leak

### DIFF
--- a/OmiseSDK/Sources/OmiseAPI/Helpers/Client+NetworkService.swift
+++ b/OmiseSDK/Sources/OmiseAPI/Helpers/Client+NetworkService.swift
@@ -40,8 +40,9 @@ extension Client {
                 }
 
                 let queue = DispatchQueue.global(qos: .background)
-                queue.asyncAfter(deadline: .now() + .seconds(timeInterval)) {
-                    self?.observeUntilChargeStatusIsFinal(
+                queue.asyncAfter(deadline: .now() + .seconds(timeInterval)) { [weak self] in
+                    guard let self = self else { return }
+                    self.observeUntilChargeStatusIsFinal(
                         tokenID: tokenID,
                         timeInterval: timeInterval,
                         attemp: attemp + 1,

--- a/OmiseSDK/Sources/Views/Screens/Choose Payment Methods/ChoosePaymentCoordinator.swift
+++ b/OmiseSDK/Sources/Views/Screens/Choose Payment Methods/ChoosePaymentCoordinator.swift
@@ -36,6 +36,10 @@ class ChoosePaymentCoordinator: NSObject, ViewAttachable {
 
         self.setupErrorView()
     }
+    
+    deinit {
+        errorView.gestureRecognizers?.forEach { errorView.removeGestureRecognizer($0) }
+    }
 
     /// Creates SelectPaymentController and attach current flow object inside created controller to be deallocated together
     ///

--- a/OmiseSDK/Sources/Views/Screens/Choose Payment Methods/Other Payments/TrueMoneyWallet/TrueMoneyPaymentFormController.swift
+++ b/OmiseSDK/Sources/Views/Screens/Choose Payment Methods/Other Payments/TrueMoneyWallet/TrueMoneyPaymentFormController.swift
@@ -88,6 +88,13 @@ class TrueMoneyPaymentFormController: UIViewController, PaymentFormUIController 
         phoneNumberLabel.text = localized("TrueMoneyWallet.field.phoneNumber")
         submitButton.setTitle(localized("TrueMoneyWallet.nextButton.title"), for: .normal)
     }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        formFields.forEach {
+            $0.removeTarget(self, action: nil, for: .allEvents)
+        }
+    }
 
     private func setupTextFieldHandlers() {
         self.formFields.forEach { field in

--- a/OmiseSDK/Sources/Views/Screens/Credit Card Payment/CreditCardPaymentController.swift
+++ b/OmiseSDK/Sources/Views/Screens/Credit Card Payment/CreditCardPaymentController.swift
@@ -175,6 +175,12 @@ class CreditCardPaymentController: UIViewController {
             bind(to: viewModel)
         }
     }
+    
+    deinit {
+        formFields.forEach {
+            $0.removeTarget(self, action: nil, for: .allEvents)
+        }
+    }
 
     private func setupLabels() {
         errorLabels.forEach {

--- a/OmiseSDKTests/ClientTests.swift
+++ b/OmiseSDKTests/ClientTests.swift
@@ -14,13 +14,53 @@ struct NetworkMockup: NetworkServiceProtocol {
     }
 }
 
+class TokenPollingNetworkMock: NetworkServiceProtocol {
+    var requestCount = 0
+    var responses: [Result<Token, Error>] = []
+    
+    func queueResponse(_ token: Token) {
+        responses.append(.success(token))
+    }
+    
+    func queueError(_ error: Error) {
+        responses.append(.failure(error))
+    }
+    
+    func send<T: Decodable>(
+        urlRequest: URLRequest,
+        dateFormatter: DateFormatter?,
+        completion: @escaping ResponseClosure<T, Error>
+    ) {
+        
+        if urlRequest.url?.absoluteString.contains("/tokens/") ?? false && T.self == Token.self {
+            let responseIndex = min(requestCount, responses.count - 1)
+            if responseIndex >= 0 && !responses.isEmpty {
+                let response = responses[responseIndex]
+                
+                DispatchQueue.main.async {
+                    switch response {
+                    case .success(let token):
+                        if let completion = completion as? ResponseClosure<Token, Error> {
+                            completion(.success(token))
+                        }
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            }
+        }
+        
+        requestCount += 1
+    }
+}
+
 class ClientTests: XCTestCase {
     let publicKey = "pkey_test_58wfnlwoxz1tbkdd993"
     let publicKeyBase64 = "cGtleV90ZXN0XzU4d2ZubHdveHoxdGJrZGQ5OTM="
     let requestTimeout: TimeInterval = 15.0
-
+    
     var testClient: Client!
-
+    
     override func setUp() {
         super.setUp()
         // swiftlint:disable force_unwrapping
@@ -32,7 +72,7 @@ class ClientTests: XCTestCase {
         )
         // swiftlint:enable force_unwrapping
     }
-
+    
     override func tearDown() {
         testClient = nil
         super.tearDown()
@@ -49,10 +89,10 @@ class ClientTests: XCTestCase {
     func testCreateTokenURLRequest() throws {
         let expectation = self.expectation(description: "Create Token Mockup Callback")
         let cardPayload = CreateTokenPayload(card: try sampleFromJSONBy(.card))
-
+        
         let networkMockup = NetworkMockup { [cardPayload] urlRequest in
             defer { expectation.fulfill() }
-
+            
             func validateURLRequest() {
                 if let data = urlRequest.httpBody, let jsonString = String(data: data, encoding: .utf8) {
                     do {
@@ -61,15 +101,15 @@ class ClientTests: XCTestCase {
                     } catch {
                         XCTFail("Unable to decode payload from encoded JSON string")
                     }
-
+                    
                 } else {
                     XCTFail("Unable to decode payload from encoded JSON string")
                 }
             }
-
+            
             validateURLRequest()
         }
-
+        
         let client = Client(publicKey: publicKey, version: "1.0.0", network: networkMockup)
         client.createToken(payload: cardPayload) { _ in
             /// Testing URLRequst in through Network Mockup closure
@@ -77,16 +117,16 @@ class ClientTests: XCTestCase {
         }
         waitForExpectations(timeout: requestTimeout, handler: nil)
     }
-
+    
     /// Testing createToken API Request.
     /// Testing if `Client` generates URLRequest with correct HTTP body to perform API request
     func testCreateApplePayTokenURLRequest() throws {
         let expectation = self.expectation(description: "Create Apple Pay Token Mockup Callback")
         let payload: CreateTokenApplePayPayload = try sampleFromJSONBy(.source(type: .applePay))
-
+        
         let networkMockup = NetworkMockup { [payload] urlRequest in
             defer { expectation.fulfill() }
-
+            
             func validateURLRequest() {
                 if let data = urlRequest.httpBody, let jsonString = String(data: data, encoding: .utf8) {
                     do {
@@ -95,15 +135,15 @@ class ClientTests: XCTestCase {
                     } catch {
                         XCTFail("Unable to decode payload from encoded JSON string")
                     }
-
+                    
                 } else {
                     XCTFail("Unable to decode payload from encoded JSON string")
                 }
             }
-
+            
             validateURLRequest()
         }
-
+        
         let client = Client(publicKey: publicKey, version: "1.0.0", network: networkMockup)
         client.createToken(applePayToken: payload) { _ in
             /// Testing URLRequst in through Network Mockup closure
@@ -111,16 +151,16 @@ class ClientTests: XCTestCase {
         }
         waitForExpectations(timeout: requestTimeout, handler: nil)
     }
-
+    
     /// Testing createToken API Request.
     /// Testing if `Client` generates URLRequest with correct HTTP body to perform API request
     func testCreateSourceURLRequest() throws {
         let expectation = self.expectation(description: "Create Source Mockup Callback")
         let sourcePayload: CreateSourcePayload = try sampleFromJSONBy(.source(type: .atome))
-
+        
         let networkMockup = NetworkMockup { [sourcePayload] urlRequest in
             defer { expectation.fulfill() }
-
+            
             func validateURLRequest() {
                 if let data = urlRequest.httpBody, let jsonString = String(data: data, encoding: .utf8) {
                     do {
@@ -129,15 +169,15 @@ class ClientTests: XCTestCase {
                     } catch {
                         XCTFail("Unable to decode payload from encoded JSON string")
                     }
-
+                    
                 } else {
                     XCTFail("Unable to decode payload from encoded JSON string")
                 }
             }
-
+            
             validateURLRequest()
         }
-
+        
         let client = Client(publicKey: publicKey, version: "1.0.0", network: networkMockup)
         client.createSource(payload: sourcePayload) { _ in
             /// Testing URLRequst in through Network Mockup closure
@@ -145,33 +185,33 @@ class ClientTests: XCTestCase {
         }
         waitForExpectations(timeout: requestTimeout, handler: nil)
     }
-
+    
     // - Mark testClient.userAgent as private
     // - Move this test to testUrlRequest
     func testUserAgent() {
         let sdkVersion = "1.0.0"
         let platform = "12.0.0"
         let device = "iPhone"
-
+        
         let expectedResult = "OmiseIOS/\(sdkVersion) iOS/\(platform) Apple/\(device)"
         let result = testClient.userAgent(sdkVersion: sdkVersion, platform: platform, device: device)
         XCTAssertEqual(expectedResult, result)
     }
-
+    
     // - Mark testClient.httpHeaders as private
     // - Move this test to testUrlRequest
     func testHTTPHeaders() {
         let userAgent = "OmiseIOSSDK/3.0.0 iOS/12.0.0 Apple/iPhone"
         let apiVersion = "2019-05-29"
         let contentType = "application/json; charset=utf8"
-
+        
         let expectedResult = [
             "Authorization": "Basic \(publicKeyBase64)",
             "User-Agent": userAgent,
             "Content-Type": contentType,
             "Omise-Version": apiVersion
         ]
-
+        
         let result = testClient.httpHeaders(
             publicKey: publicKey,
             userAgent: userAgent,
@@ -179,5 +219,56 @@ class ClientTests: XCTestCase {
             contentType: contentType
         )
         XCTAssertEqual(expectedResult, result)
+    }
+    
+    func testObserveChargeStatus() {
+        let expectation = XCTestExpectation(description: "Observe charge status")
+        let mockNetwork = TokenPollingNetworkMock()
+        
+        let pendingToken = Token(
+            id: "tok_test_1234",
+            isLiveMode: false,
+            isUsed: false,
+            card: nil,
+            chargeStatus: .pending
+        )
+        
+        let successToken = Token(
+            id: "tok_test_1234",
+            isLiveMode: false,
+            isUsed: true,
+            card: nil,
+            chargeStatus: .successful
+        )
+        
+        mockNetwork.queueResponse(pendingToken)
+        mockNetwork.queueResponse(successToken)
+        
+        // Create the client with the mock network
+        let testClient = Client(
+            publicKey: "pkey_test_123",
+            version: "test_version",
+            network: mockNetwork,
+            apiURL: nil,
+            vaultURL: nil
+        )
+        
+        // Execute
+        testClient.observeChargeStatus(tokenID: "tok_test_1234") { result in
+            switch result {
+            case .success(let status):
+                // Verify the final status is successful
+                XCTAssertEqual(status, .successful)
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+        
+        // Wait for the async operation to complete
+        wait(for: [expectation], timeout: 10.0)
+        
+        // Verify the token endpoint was called multiple times
+        XCTAssertEqual(mockNetwork.requestCount, 2)
     }
 }

--- a/OmiseSDKTests/Not Refactored Tests/TrueMoneyPaymentFormControllerTests.swift
+++ b/OmiseSDKTests/Not Refactored Tests/TrueMoneyPaymentFormControllerTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import OmiseSDK
+
+class TrueMoneyPaymentFormControllerTests: XCTestCase {
+    
+    var sut: TrueMoneyPaymentFormController?
+    weak var weakController: TrueMoneyPaymentFormController?
+    
+    override func setUp() {
+        super.setUp()
+        // Create a controller instance
+        sut = TrueMoneyPaymentFormController(nibName: nil, bundle: .omiseSDK)
+        weakController = sut
+        
+        // Load the view to trigger viewDidLoad
+        _ = sut?.view
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+    
+    func testControllerDeallocatesProperly() {
+        XCTAssertNotNil(sut)
+        XCTAssertNotNil(weakController)
+        
+        var notificationReceived = false
+        let notificationCenter = NotificationCenter.default
+        
+        let observer = notificationCenter.addObserver(
+            forName: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            notificationReceived = true
+        }
+        
+        notificationCenter.post(name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        
+        let expectation1 = XCTestExpectation(description: "Initial notification received")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 1.0)
+        
+        XCTAssertTrue(notificationReceived, "Test observer should receive notifications")
+        
+        notificationReceived = false
+        sut = nil
+        
+        // Force a garbage collection-like sweep
+        autoreleasepool {
+            for _ in 0...1000 {
+                _ = NSObject()
+            }
+        }
+        
+        let expectation2 = XCTestExpectation(description: "Wait for deallocation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation2.fulfill()
+        }
+        wait(for: [expectation2], timeout: 1.0)
+        
+        XCTAssertNil(weakController, "Controller should be deallocated")
+        
+        notificationCenter.removeObserver(observer)
+    }
+    
+    func testTextFieldTargetsRemoved() {
+        class TestTextField: OmiseTextField {
+            var actionInvoked = false
+            
+            override func sendActions(for controlEvents: UIControl.Event) {
+                actionInvoked = true
+                super.sendActions(for: controlEvents)
+            }
+        }
+        
+        let testField = TestTextField()
+        sut?.formFields = [testField]
+        
+        testField.sendActions(for: .editingChanged)
+        XCTAssertTrue(testField.actionInvoked, "Action should be invoked initially")
+        
+        testField.actionInvoked = false
+        
+        sut = nil
+        
+        autoreleasepool {
+            for _ in 0...1000 {
+                _ = NSObject()
+            }
+        }
+        let expectation = XCTestExpectation(description: "Wait for deallocation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertNil(weakController, "Controller should be deallocated")
+        
+        testField.sendActions(for: .editingChanged)
+        XCTAssertTrue(true, "No crash when sending actions after controller deallocation")
+    }
+}

--- a/dev.xcodeproj/project.pbxproj
+++ b/dev.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		2FC27E1E2D6DDA0F001E5857 /* MockApplePayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC27E1D2D6DDA0F001E5857 /* MockApplePayViewModel.swift */; };
 		2FC4CA7A2D64ED880005EC4A /* ApplePayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC4CA792D64ED880005EC4A /* ApplePayViewController.swift */; };
 		2FC4CA7C2D64ED960005EC4A /* ApplePayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC4CA7B2D64ED910005EC4A /* ApplePayViewModel.swift */; };
+		2FF94B422D946711008126D3 /* TrueMoneyPaymentFormControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8FC5E92D94658500028D2A /* TrueMoneyPaymentFormControllerTests.swift */; };
 		73F9BA4B25E6053700F55CA8 /* FPXPaymentFormController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F9BA4A25E6053700F55CA8 /* FPXPaymentFormController.swift */; };
 		7501265D2B87CB6500ED5E14 /* PaymentInputsFormController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7501265C2B87CB6500ED5E14 /* PaymentInputsFormController.swift */; };
 		7501265F2B8893C900ED5E14 /* PaymentFormController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7501265E2B8893C900ED5E14 /* PaymentFormController.swift */; };
@@ -329,6 +330,7 @@
 		2F5D98F82D6EBA9600B5ECB4 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
 		2F5D98FA2D6EC26100B5ECB4 /* MockChoosePaymentMethodDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChoosePaymentMethodDelegate.swift; sourceTree = "<group>"; };
 		2F5D99012D6ECA4100B5ECB4 /* SelectPaymentMethodViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPaymentMethodViewModelTest.swift; sourceTree = "<group>"; };
+		2F8FC5E92D94658500028D2A /* TrueMoneyPaymentFormControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrueMoneyPaymentFormControllerTests.swift; sourceTree = "<group>"; };
 		2F9682162D657EFA00A7AFDA /* ApplePaymentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePaymentHandler.swift; sourceTree = "<group>"; };
 		2F9682192D65A45400A7AFDA /* MockApplePayInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApplePayInterface.swift; sourceTree = "<group>"; };
 		2F96821B2D65A4A600A7AFDA /* ApplePaymentHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePaymentHandlerTests.swift; sourceTree = "<group>"; };
@@ -784,6 +786,7 @@
 		750708E82B79125200A48DD0 /* Not Refactored Tests */ = {
 			isa = PBXGroup;
 			children = (
+				2F8FC5E92D94658500028D2A /* TrueMoneyPaymentFormControllerTests.swift */,
 				F615CBFB2615696100E1A2D9 /* Views */,
 				7509D4DE2A1AA1060050AB38 /* Atome */,
 				8A3C10572159FCE900BEFD8A /* BadRequestAPIErrorParsingTestCase.swift */,
@@ -1830,6 +1833,7 @@
 				2F96821E2D65AC1600A7AFDA /* ApplePayViewModelTests.swift in Sources */,
 				F615CBF8261565D600E1A2D9 /* CardExpiryDatePickerTests.swift in Sources */,
 				758A4E9F2BE3DFDF005E7B5A /* URL+PathComponentsTests.swift in Sources */,
+				2FF94B422D946711008126D3 /* TrueMoneyPaymentFormControllerTests.swift in Sources */,
 				758A4E922BE38AFD005E7B5A /* UICustomizationTests.swift in Sources */,
 				75E0EB722B7A962600E3198A /* CreateSourcePayloadTests.swift in Sources */,
 				753279382A31B40F008048AD /* CountryListViewModelMockup.swift in Sources */,


### PR DESCRIPTION
## Description
- add weak self to prevent retaining cycle in observing charge status
- remove gesture recognizer when the class is deinit to prevent strong reference cycle
- remove observer when the class is deinit to prevent memory leak