### PR TITLE
fix JPY currency precision for apple pay

### DIFF
--- a/OmiseSDK/Sources/Views/Screens/Choose Payment Methods/Other Payments/ApplePay/ApplePayViewModel.swift
+++ b/OmiseSDK/Sources/Views/Screens/Choose Payment Methods/Other Payments/ApplePay/ApplePayViewModel.swift
@@ -107,7 +107,9 @@ extension ApplePayViewModel: ApplePayViewModelInput {
     /// - Parameter completion: A closure called after the payment process completes.
     func startPayment(completion: @escaping () -> Void) {
         // Convert the amount from cents to a decimal value (e.g., 999 becomes 9.99).
-        let decimalAmount = NSDecimalNumber(value: amount).multiplying(by: 0.01)
+        let decimalAmount = currency == Currency.jpy.code
+        ? NSDecimalNumber(value: amount)
+        : NSDecimalNumber(value: amount).multiplying(by: 0.01)
         
         let request = applePaymentHandler.createPKPaymentRequest(with: decimalAmount,
                                                                  currency: currency,

--- a/OmiseSDKTests/ApplePay/ApplePayViewModelTests.swift
+++ b/OmiseSDKTests/ApplePay/ApplePayViewModelTests.swift
@@ -145,4 +145,46 @@ class ApplePayViewModelTests: XCTestCase {
         XCTAssertFalse(mockDelegate.didFinishApplePayCalled, "Delegate should not be called when no payment and no error are returned")
     }
     
+    /// Test payment currency for JPY
+    func testStartPayment_JPY_Success() {
+        viewModel = ApplePayViewModel(
+            applePayInfo: dummyApplePayInfo,
+            amount: 100,
+            currency: Currency.jpy.code,
+            country: .init(code: "SG"),
+            applePaymentHandler: mockHandler,
+            delegate: mockDelegate
+        )
+        let expectation = self.expectation(description: "Payment returned successfully")
+        
+        viewModel.input.startPayment {
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+        
+        XCTAssertEqual(mockHandler.amountToApplePayRequest, NSDecimalNumber(value: 100))
+    }
+    
+    /// Test payment currency for THB
+    func testStartPayment_THB_Success() {
+        viewModel = ApplePayViewModel(
+            applePayInfo: dummyApplePayInfo,
+            amount: 10000,
+            currency: Currency.thb.code,
+            country: .init(code: "TH"),
+            applePaymentHandler: mockHandler,
+            delegate: mockDelegate
+        )
+        let expectation = self.expectation(description: "Payment returned successfully")
+        
+        viewModel.input.startPayment {
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+        
+        XCTAssertEqual(mockHandler.amountToApplePayRequest, NSDecimalNumber(value: 100))
+    }
+    
 }

--- a/OmiseSDKTests/ApplePay/Mocks/MockApplePaymentHandler.swift
+++ b/OmiseSDKTests/ApplePay/Mocks/MockApplePaymentHandler.swift
@@ -7,6 +7,7 @@ class MockApplePaymentHandler: ApplePaymentHandlerType {
     // Simulated values
     var mockPayment: PKPayment?
     var mockError: Error?
+    var amountToApplePayRequest: NSDecimalNumber = .zero
     
     func createPKPaymentRequest(
         with amount: NSDecimalNumber,
@@ -15,7 +16,8 @@ class MockApplePaymentHandler: ApplePaymentHandlerType {
         requiredBillingAddress: Bool,
         merchantId: String
     ) -> PKPaymentRequest {
-        PKPaymentRequest()
+        amountToApplePayRequest = amount
+        return PKPaymentRequest()
     }
     
     func createPaymentAuthViewController(from request: PKPaymentRequest) -> PKPaymentAuthorizationController {


### PR DESCRIPTION
## Description
- fix JPY currency precision for ApplePay
- ref: https://docs.omise.co/currency-and-amount#units