### PR TITLE
Fix Swift 5 build by guarding compiler check

### DIFF
--- a/OmiseSDK/ToolKit/UI Extensions/UIControl.State+Hashable.swift
+++ b/OmiseSDK/ToolKit/UI Extensions/UIControl.State+Hashable.swift
@@ -1,8 +1,16 @@
 import UIKit
 /// ref: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md
-/// if we support iOS 13 and above, can remove this extension
+/// Provides Hashable conformance for older Swift toolchains.
+#if compiler(>=6)
 extension UIControl.State: @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(rawValue)
     }
 }
+#else
+extension UIControl.State: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+}
+#endif


### PR DESCRIPTION
## Description
- Wrapped the UIControl.State hashable extension in a` #if compiler(>=6)` guard so Swift 6 builds keep `@retroactive` while `Swift 5.x` still compiles with a plain Hashable conformance
