### PR TITLE
Release/v5.6.2

### DIFF
--- a/OmiseSDK/Sources/OmiseSDK.swift
+++ b/OmiseSDK/Sources/OmiseSDK.swift
@@ -6,7 +6,7 @@ public class OmiseSDK {
     public static var shared = OmiseSDK(publicKey: "pkey_")
 
     /// OmiseSDK version
-    public let version: String = "5.6.1"
+    public let version: String = "5.6.2"
 
     /// Public Key associated with this instance of OmiseSDK
     public let publicKey: String

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "ThreeDS_SDK",
-        "repositoryURL": "https://github.com/ios-3ds-sdk/SPM",
+        "repositoryURL": "https://github.com/netceteragroup/ios-3ds-sdk-spm",
         "state": {
           "branch": null,
-          "revision": "a4e55d7f10294ea81abd1db393ae05606a5efa46",
+          "revision": "3cdaa8dc7d157a11f69a6617a5dea5a41ec63898",
           "version": "2.4.0"
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ios-3ds-sdk/SPM", .exact("2.4.0"))
+        .package(url: "https://github.com/netceteragroup/ios-3ds-sdk-spm", .exact("2.4.0"))
     ],
     targets: [
         .target(
             name: "OmiseSDK",
             dependencies: [
-                .product(name: "ThreeDS_SDK", package: "SPM")
+                .product(name: "ThreeDS_SDK", package: "ios-3ds-sdk-spm")
             ],
             path: "OmiseSDK",
             exclude: ["Info.plist"],

--- a/dev.xcodeproj/project.pbxproj
+++ b/dev.xcodeproj/project.pbxproj
@@ -1952,7 +1952,7 @@
 			);
 			mainGroup = 2259310E1CE3210700841B86;
 			packageReferences = (
-				758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "SPM" */,
+				758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "ios-3ds-sdk-spm" */,
 			);
 			productRefGroup = 225931191CE3210700841B86 /* Products */;
 			projectDirPath = "";
@@ -2966,9 +2966,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "SPM" */ = {
+		758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "ios-3ds-sdk-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ios-3ds-sdk/SPM.git";
+			repositoryURL = "https://github.com/netceteragroup/ios-3ds-sdk-spm";
 			requirement = {
 				kind = exactVersion;
 				version = 2.4.0;
@@ -2979,7 +2979,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		2F9F58D72D6E28D600240952 /* ThreeDS_SDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "SPM" */;
+			package = 758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "ios-3ds-sdk-spm" */;
 			productName = ThreeDS_SDK;
 		};
 		7509D4ED2A1D1F9F0050AB38 /* OmiseTestSDK */ = {
@@ -2992,12 +2992,12 @@
 		};
 		758A4E832BE38AC3005E7B5A /* ThreeDS_SDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "SPM" */;
+			package = 758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "ios-3ds-sdk-spm" */;
 			productName = ThreeDS_SDK;
 		};
 		758A4E852BE38AD0005E7B5A /* ThreeDS_SDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "SPM" */;
+			package = 758A4E822BE38AC3005E7B5A /* XCRemoteSwiftPackageReference "ios-3ds-sdk-spm" */;
 			productName = ThreeDS_SDK;
 		};
 		75D13E0E2B8678530073A831 /* OmiseSwiftUIKit */ = {

--- a/dev.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dev.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "ThreeDS_SDK",
-        "repositoryURL": "https://github.com/ios-3ds-sdk/SPM.git",
+        "repositoryURL": "https://github.com/netceteragroup/ios-3ds-sdk-spm",
         "state": {
           "branch": null,
-          "revision": "a4e55d7f10294ea81abd1db393ae05606a5efa46",
+          "revision": "3cdaa8dc7d157a11f69a6617a5dea5a41ec63898",
           "version": "2.4.0"
         }
       }


### PR DESCRIPTION
## Description
- release v5.6.2
- change netcetera url from the old to new one
- old url: https://github.com/ios-3ds-sdk/SPM?
- new url: https://github.com/netceteragroup/ios-3ds-sdk-spm



### More information (if any)  
- as of new Netcetera planned to decommission the old url in 2 weeks.


## Business impact (if any)
N/A
But need to communicate merchants to update v5.6.2 once the old url is decommissioned. Otherwise, the dev team will not be able to build the app. (NO disruption on the released apps.) 
  
## Pre- or post-deployment steps (if any)
- merge to master
- create tag v5.6.2
 
## Rollback procedure
Default rollback procedure 
